### PR TITLE
fix paths to images in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -46,13 +46,13 @@ The following guide describes how to setup the OpenTelemetry demo with Elastic O
 ## Explore and analyze the data With Elastic
 
 ### Service map
-![Service map](service-map.png "Service map")
+![Service map](.github/service-map.png "Service map")
 
 ### Traces
-![Traces](trace.png "Traces")
+![Traces](.github/trace.png "Traces")
 
 ### Correlation
-![Correlation](correlation.png "Correlation")
+![Correlation](.github/correlation.png "Correlation")
 
 ### Logs
-![Logs](logs.png "Logs")
+![Logs](.github/logs.png "Logs")


### PR DESCRIPTION
These render when looking at [.github/README.md](https://github.com/elastic/opentelemetry-demo/tree/main/.github) but not on the more commonly viewed https://github.com/elastic/opentelemetry-demo/tree/main - fixes the latter at the expense of the former