### PR TITLE
Revert "fix paths to images in README"

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -46,13 +46,13 @@ The following guide describes how to setup the OpenTelemetry demo with Elastic O
 ## Explore and analyze the data With Elastic
 
 ### Service map
-![Service map](.github/service-map.png "Service map")
+![Service map](service-map.png "Service map")
 
 ### Traces
-![Traces](.github/trace.png "Traces")
+![Traces](trace.png "Traces")
 
 ### Correlation
-![Correlation](.github/correlation.png "Correlation")
+![Correlation](correlation.png "Correlation")
 
 ### Logs
-![Logs](.github/logs.png "Logs")
+![Logs](logs.png "Logs")


### PR DESCRIPTION
Reverts elastic/opentelemetry-demo#5

This seems to have been fixed on the GH side, at least it works in [this preview](https://github.com/graphaelli/opentelemetry-demo/tree/revert-5-fix-readme-images)