### PR TITLE
Remove invalid `filter` processor

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -33,7 +33,7 @@ service:
       exporters: [spanmetrics, otlp/elastic]
     metrics:
       receivers: [otlp, spanmetrics]
-      processors: [filter, batch]
+      processors: [batch]
       exporters: [otlp/elastic]
     logs:
       receivers: [otlp]


### PR DESCRIPTION
The filter processor was previously deleted but still lingering in the config