### PR TITLE
add Java Elastic distribution for Ad and Fraud services

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -3,7 +3,7 @@
 
 The following guide describes how to setup the OpenTelemetry demo with Elastic Observability using [Docker compose](#docker-compose) or [Kubernetes](#kubernetes). This fork introduces several changes to the agents used in the demo:
 
-- The Java agent within the [Ad](../src/adservice/Dockerfile#L27) and [Fraud Detection](../src/frauddetectionservice/Dockerfile#L21) services have been replaced with the Elastic distribution of the OpenTelemetry Java Agent. You can find more information about the Elastic distribution in [this blog post](https://www.elastic.co/observability-labs/blog/elastic-distribution-opentelemetry-java-agent).
+- The Java agent within the [Ad](../src/adservice/Dockerfile.elastic) and [Fraud Detection](../src/frauddetectionservice/Dockerfile.elastic) services have been replaced with the Elastic distribution of the OpenTelemetry Java Agent. You can find more information about the Elastic distribution in [this blog post](https://www.elastic.co/observability-labs/blog/elastic-distribution-opentelemetry-java-agent).
 
 ## Docker compose
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable-next-line -->
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OTel logo" width="32"> :heavy_plus_sign: <img src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt601c406b0b5af740/620577381692951393fdf8d6/elastic-logo-cluster.svg" alt="OTel logo" width="32"> OpenTelemetry Demo with Elastic Observability
 
-The following guide describes how to setup the OpenTelemetry demo with Elastic Observability using [Docker compose](#docker-compose) or [Kubernetes](#kubernetes).
+The following guide describes how to setup the OpenTelemetry demo with Elastic Observability using [Docker compose](#docker-compose) or [Kubernetes](#kubernetes). This fork introduces several changes to the agents used in the demo:
+
+- The Java agent within the [Ad](../src/adservice/Dockerfile#L27) and [Fraud Detection](../src/frauddetectionservice/Dockerfile#L21) services have been replaced with the Elastic distribution of the OpenTelemetry Java Agent. You can find more information about the Elastic distribution in [this blog post](https://www.elastic.co/observability-labs/blog/elastic-distribution-opentelemetry-java-agent).
 
 ## Docker compose
 

--- a/src/adservice/Dockerfile.elastic
+++ b/src/adservice/Dockerfile.elastic
@@ -1,0 +1,28 @@
+FROM eclipse-temurin:21-jdk as builder
+
+WORKDIR /usr/src/app/
+
+COPY ./src/adservice/gradlew* ./src/adservice/settings.gradle* ./src/adservice/build.gradle ./
+COPY ./src/adservice/gradle ./gradle
+
+RUN ./gradlew
+RUN ./gradlew downloadRepos
+
+COPY ./src/adservice/ ./
+COPY ./pb/ ./proto
+RUN ./gradlew installDist -PprotoSourceDir=./proto
+
+# -----------------------------------------------------------------------------
+
+FROM eclipse-temurin:21-jre
+
+ARG version=0.3.2
+WORKDIR /usr/src/app/
+
+COPY --from=builder /usr/src/app/ ./
+ADD --chmod=644 https://repo1.maven.org/maven2/co/elastic/otel/elastic-otel-javaagent/$version/elastic-otel-javaagent-$version.jar /usr/src/app/opentelemetry-javaagent.jar
+ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
+ENV ELASTIC_OTEL_INFERRED_SPANS_ENABLED=true
+
+EXPOSE ${AD_SERVICE_PORT}
+ENTRYPOINT [ "./build/install/opentelemetry-demo-ad-service/bin/AdService" ]

--- a/src/frauddetectionservice/Dockerfile.elastic
+++ b/src/frauddetectionservice/Dockerfile.elastic
@@ -1,0 +1,21 @@
+FROM gradle:8-jdk17 AS builder
+
+WORKDIR /usr/src/app/
+
+COPY ./src/frauddetectionservice/ ./
+COPY ./pb/ ./src/main/proto/
+RUN gradle shadowJar
+
+# -----------------------------------------------------------------------------
+
+FROM gcr.io/distroless/java17-debian11
+
+ARG version=0.3.2
+WORKDIR /usr/src/app/
+
+COPY --from=builder /usr/src/app/build/libs/frauddetectionservice-1.0-all.jar ./
+ADD --chmod=644 https://repo1.maven.org/maven2/co/elastic/otel/elastic-otel-javaagent/$version/elastic-otel-javaagent-$version.jar /usr/src/app/opentelemetry-javaagent.jar
+ENV JAVA_TOOL_OPTIONS=-javaagent:/app/opentelemetry-javaagent.jar
+ENV ELASTIC_OTEL_INFERRED_SPANS_ENABLED=true
+
+ENTRYPOINT [ "java", "-jar", "frauddetectionservice-1.0-all.jar" ]


### PR DESCRIPTION
# Changes

Add Elastic Dockerfiles (Dockerfile.elastic) that uses the Elastic's Java agent distribution for the Ad and Fraud detection services. Those Dockerfiles are a copy of the upstream version but replacing the Java agent.
The idea is to later [parametrize](https://github.com/elastic/opentelemetry-demo/blob/main/docker-compose.yml#L223) the `Dockerfile` file used in the `docker-compose.yml` to point to our custom Dockerfile using the new [.env.override file](https://github.com/elastic/opentelemetry-demo/blob/main/.env.override).

- Dependabot will be configured in a future PR to maintain the agent version up-to-date.

## Alternatives

- Modify the Dockerfile used in the upstream version:
    - Pros: no need to make to parametrize Dockerfile (upstream changes)
    - Cons:
        - Merge conflicts

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
