### PR TITLE
chore: bump Java agent to 0.4.0

### DIFF
--- a/src/adservice/Dockerfile.elastic
+++ b/src/adservice/Dockerfile.elastic
@@ -16,7 +16,7 @@ RUN ./gradlew installDist -PprotoSourceDir=./proto
 
 FROM eclipse-temurin:21-jre
 
-ARG version=0.3.2
+ARG version=0.4.0
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/ ./

--- a/src/frauddetectionservice/Dockerfile.elastic
+++ b/src/frauddetectionservice/Dockerfile.elastic
@@ -10,7 +10,7 @@ RUN gradle shadowJar
 
 FROM gcr.io/distroless/java17-debian11
 
-ARG version=0.3.2
+ARG version=0.4.0
 WORKDIR /usr/src/app/
 
 COPY --from=builder /usr/src/app/build/libs/frauddetectionservice-1.0-all.jar ./


### PR DESCRIPTION
# Changes

Bump Elastic Java agent, see: https://github.com/elastic/elastic-otel-java/releases/tag/v0.4.0

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
