### PR TITLE
override demo images environment variables

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -1,5 +1,12 @@
 # DO NOT PUSH CHANGES OF THIS FILE TO opentelemetry/opentelemetry-demo
 # PLACE YOUR .env ENVIRONMENT VARIABLES OVERRIDES IN THIS FILE
 
+# Demo Elastic App version
+IMAGE_VERSION=1.10.1
+IMAGE_NAME=ghcr.io/elastic/opentelemetry-demo
+
+# *********************
+# Elastic Demo Services
+# *********************
 AD_SERVICE_DOCKERFILE=./src/adservice/Dockerfile.elastic
 FRAUD_SERVICE_DOCKERFILE=./src/frauddetectionservice/Dockerfile.elastic


### PR DESCRIPTION
# Changes

Override image environment variable to point latest custom images: ghcr.io/elastic/opentelemetry-demo

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
