### PR TITLE
add the Elastic Collector distribution

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -14,6 +14,6 @@ FRAUD_SERVICE_DOCKERFILE=./src/frauddetectionservice/Dockerfile.elastic
 # *********************
 # Elastic Collector
 # *********************
-COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/beats/elastic-agent:8.15.0-SNAPSHOT
+COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/beats/elastic-agent:8.15.0-7b611e39-SNAPSHOT
 OTEL_COLLECTOR_CONFIG=./src/otelcollector/otelcol-elastic-config.yaml
 OTEL_COLLECTOR_CONFIG_EXTRAS=./src/otelcollector/otelcol-elastic-config-extras.yaml

--- a/.env.override
+++ b/.env.override
@@ -10,3 +10,10 @@ IMAGE_NAME=ghcr.io/elastic/opentelemetry-demo
 # *********************
 AD_SERVICE_DOCKERFILE=./src/adservice/Dockerfile.elastic
 FRAUD_SERVICE_DOCKERFILE=./src/frauddetectionservice/Dockerfile.elastic
+
+# *********************
+# Elastic Collector
+# *********************
+COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/beats/elastic-agent:8.15.0-SNAPSHOT
+OTEL_COLLECTOR_CONFIG=./src/otelcollector/otelcol-elastic-config.yaml
+OTEL_COLLECTOR_CONFIG_EXTRAS=./src/otelcollector/otelcol-elastic-config-extras.yaml

--- a/.github/README.md
+++ b/.github/README.md
@@ -7,15 +7,17 @@ The following guide describes how to setup the OpenTelemetry demo with Elastic O
 - The .NET agent within the [Cart service](../src/cartservice/src/Directory.Build.props) has been replaced with the Elastic distribution of the OpenTelemetry .NET Agent. You can find more information about the Elastic distribution in [this blog post](https://www.elastic.co/observability-labs/blog/elastic-opentelemetry-distribution-dotnet-applications).
 - The Elastic distribution of the OpenTelemetry Node.js Agent has replaced the OpenTelemetry Node.js agent in the [Payment service](../src/paymentservice/package.json). Additional details about the Elastic distribution are available in [this blog post](https://www.elastic.co/observability-labs/blog/elastic-opentelemetry-distribution-node-js).
 
+Additionally, the OpenTelemetry Contrib collector has also been changed to the [Elastic OpenTelemetry Collector distribution](https://github.com/elastic/elastic-agent/blob/main/internal/pkg/otel/README.md). This ensures a more integrated and optimized experience with Elastic Observability.
+
 ## Docker compose
 
 1. Start a free trial on [Elastic Cloud](https://cloud.elastic.co/) and copy the `endpoint` and `secretToken` from the Elastic APM setup instructions in your Kibana.
-1. Open the file `src/otelcollector/otelcol-config-extras.yml` in an editor and replace the following two placeholders:
+1. Open the file `src/otelcollector/otelcol-elastic-config-extras.yaml` in an editor and replace the following two placeholders:
    - `YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX`: your Elastic APM endpoint (*without* `https://` prefix) that *must* also include the port (example: `1234567.apm.us-west2.gcp.elastic-cloud.com:443`).
    - `YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token.
 1. Start the demo with the following command from the repository's root directory:
    ```
-   docker-compose up -d
+   make start
    ```
 
 ## Kubernetes

--- a/.github/README.md
+++ b/.github/README.md
@@ -48,6 +48,9 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
    # !(when an older helm open-telemetry repo exists) update the open-telemetry helm repo
    helm repo update open-telemetry
 
+   # deploy the configuration for the Elastic OpenTelemetry collector distribution
+   kubectl apply -f configmap-elastic.yaml
+
    # deploy the demo through helm install
    helm install -f values.yaml my-otel-demo open-telemetry/opentelemetry-demo
    ```

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -582,7 +582,8 @@ services:
         limits:
           memory: 200M
     restart: unless-stopped
-    command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
+    command: ["otel", "--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
+    entrypoint: [ /usr/share/elastic-agent/elastic-agent ]
     volumes:
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -692,7 +692,8 @@ services:
         limits:
           memory: 200M
     restart: unless-stopped
-    command: [ "--config=/etc/otelcol-config.yml", "--config=/etc/otelcol-config-extras.yml" ]
+    command: ["otel", "--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
+    entrypoint: [ /usr/share/elastic-agent/elastic-agent ]
     volumes:
       - ${OTEL_COLLECTOR_CONFIG}:/etc/otelcol-config.yml
       - ${OTEL_COLLECTOR_CONFIG_EXTRAS}:/etc/otelcol-config-extras.yml

--- a/kubernetes/elastic-helm/configmap-elastic.yaml
+++ b/kubernetes/elastic-helm/configmap-elastic.yaml
@@ -14,7 +14,7 @@ data:
     exporters:
       debug: {}
       otlp/elastic:
-        endpoint: ${ELASTIC_APM_ENDPOINT}
+        endpoint: ${env:ELASTIC_APM_ENDPOINT}
         compression: none
         headers:
           Authorization: Bearer ${ELASTIC_APM_SECRET_TOKEN}

--- a/kubernetes/elastic-helm/configmap-elastic.yaml
+++ b/kubernetes/elastic-helm/configmap-elastic.yaml
@@ -17,7 +17,7 @@ data:
         endpoint: ${ELASTIC_APM_ENDPOINT}
         compression: none
         headers:
-          Authorization: ApiKey ${ELASTIC_APM_SECRET_TOKEN}
+          Authorization: Bearer ${ELASTIC_APM_SECRET_TOKEN}
     extensions:
     processors:
       batch: {}

--- a/kubernetes/elastic-helm/configmap-elastic.yaml
+++ b/kubernetes/elastic-helm/configmap-elastic.yaml
@@ -1,5 +1,4 @@
 ---
-# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,36 +21,6 @@ data:
     extensions:
     processors:
       batch: {}
-      k8sattributes:
-        extract:
-          metadata:
-          - k8s.namespace.name
-          - k8s.deployment.name
-          - k8s.statefulset.name
-          - k8s.daemonset.name
-          - k8s.cronjob.name
-          - k8s.job.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - k8s.pod.start_time
-        filter:
-          node_from_env_var: K8S_NODE_NAME
-        passthrough: false
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.ip
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: connection
-      resource:
-        attributes:
-        - action: insert
-          from_attribute: k8s.pod.uid
-          key: service.instance.id
     receivers:
       httpcheck/frontendproxy:
         targets:
@@ -74,8 +43,6 @@ data:
           - debug
           - otlp/elastic
           processors:
-          - k8sattributes
-          - resource
           - batch
           receivers:
           - otlp
@@ -84,8 +51,6 @@ data:
           - otlp/elastic
           - debug
           processors:
-          - k8sattributes
-          - resource
           - batch
           receivers:
           - httpcheck/frontendproxy
@@ -97,8 +62,6 @@ data:
           - debug
           - spanmetrics
           processors:
-          - k8sattributes
-          - resource
           - batch
           receivers:
           - otlp

--- a/kubernetes/elastic-helm/configmap-elastic.yaml
+++ b/kubernetes/elastic-helm/configmap-elastic.yaml
@@ -1,0 +1,108 @@
+---
+# Source: opentelemetry-demo/charts/opentelemetry-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elastic-otelcol-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: otelcol
+
+data:
+  relay: |
+    connectors:
+      spanmetrics: {}
+    exporters:
+      debug: {}
+      otlp/elastic:
+        endpoint: ${ELASTIC_APM_ENDPOINT}
+        compression: none
+        headers:
+          Authorization: ApiKey ${ELASTIC_APM_SECRET_TOKEN}
+    extensions:
+    processors:
+      batch: {}
+      k8sattributes:
+        extract:
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      resource:
+        attributes:
+        - action: insert
+          from_attribute: k8s.pod.uid
+          key: service.instance.id
+    receivers:
+      httpcheck/frontendproxy:
+        targets:
+        - endpoint: http://example-frontendproxy:8080
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            cors:
+              allowed_origins:
+              - http://*
+              - https://*
+            endpoint: ${env:MY_POD_IP}:4318
+    service:
+      extensions:
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          - otlp/elastic
+          processors:
+          - k8sattributes
+          - resource
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - otlp/elastic
+          - debug
+          processors:
+          - k8sattributes
+          - resource
+          - batch
+          receivers:
+          - httpcheck/frontendproxy
+          - otlp
+          - spanmetrics
+        traces:
+          exporters:
+          - otlp/elastic
+          - debug
+          - spanmetrics
+          processors:
+          - k8sattributes
+          - resource
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        metrics:
+          address: ${env:MY_POD_IP}:8888
+

--- a/kubernetes/elastic-helm/values.yaml
+++ b/kubernetes/elastic-helm/values.yaml
@@ -4,6 +4,12 @@ default:
     tag: 1.10.1
 
 opentelemetry-collector:
+  image:
+    repository: docker.elastic.co/beats/elastic-agent
+    tag: 8.15.0-SNAPSHOT
+  command:
+    name: "/usr/share/elastic-agent/elastic-agent"
+    extraArgs: ["otel", "-c", "/etc/elastic-agent/otel.yaml"]
   mode: "deployment"
   presets:
     kubernetesAttributes:
@@ -24,38 +30,23 @@ opentelemetry-collector:
         secretKeyRef:
           name: elastic-secret
           key: elastic_apm_secret_token
-  config:
-    exporters:
-      otlp/elastic:
-        endpoint: ${ELASTIC_APM_ENDPOINT}
-        compression: none
-        headers:
-          Authorization: Bearer ${ELASTIC_APM_SECRET_TOKEN}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: ${MY_POD_IP}:4317
-          http:
-            cors:
-              allowed_origins:
-              - http://*
-              - https://*
-            endpoint: ${MY_POD_IP}:4318
-    service:
-      pipelines:
-        traces:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlp/elastic]
-        metrics:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlp/elastic]
-        logs:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [otlp/elastic]
+
+  configMap:
+    create: false
+    existingName: elastic-otelcol-agent
+
+  livenessProbe:
+    httpGet:
+      port: 8888
+      path: metrics
+  readinessProbe:
+    httpGet:
+      port: 8888
+      path: metrics
+
+opensearch:
+  enabled: false
+
 grafana:
   enabled: false
 

--- a/kubernetes/elastic-helm/values.yaml
+++ b/kubernetes/elastic-helm/values.yaml
@@ -6,7 +6,7 @@ default:
 opentelemetry-collector:
   image:
     repository: docker.elastic.co/beats/elastic-agent
-    tag: 8.15.0-7b611e39-SNAPSHOT
+    tag: 8.15.0-SNAPSHOT
   command:
     name: "/usr/share/elastic-agent/elastic-agent"
     extraArgs: ["otel", "-c", "/etc/elastic-agent/otel.yaml"]

--- a/kubernetes/elastic-helm/values.yaml
+++ b/kubernetes/elastic-helm/values.yaml
@@ -6,7 +6,7 @@ default:
 opentelemetry-collector:
   image:
     repository: docker.elastic.co/beats/elastic-agent
-    tag: 8.15.0-SNAPSHOT
+    tag: 8.15.0-7b611e39-SNAPSHOT
   command:
     name: "/usr/share/elastic-agent/elastic-agent"
     extraArgs: ["otel", "-c", "/etc/elastic-agent/otel.yaml"]

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -16,26 +16,3 @@
 #    pipelines:
 #      traces:
 #        exporters: [spanmetrics, otlphttp/example]
-
-exporters:
-  otlp/elastic:
-    # !!! Elastic APM https endpoint WITHOUT the "https://" prefix
-    endpoint: "YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX"
-    compression: none
-    headers:
-      Authorization: "Bearer YOUR_APM_SECRET_TOKEN"
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [spanmetrics, otlp/elastic]
-    metrics:
-      receivers: [otlp, spanmetrics]
-      processors: [batch]
-      exporters: [otlp/elastic]
-    logs:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlp/elastic]

--- a/src/otelcollector/otelcol-elastic-config-extras.yaml
+++ b/src/otelcollector/otelcol-elastic-config-extras.yaml
@@ -1,0 +1,41 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# extra settings to be merged into OpenTelemetry Collector configuration
+# do not delete this file
+
+## Example configuration for sending data to your own OTLP HTTP backend
+## Note: the spanmetrics exporter must be included in the exporters array
+## if overriding the traces pipeline.
+##
+#  exporters:
+#    otlphttp/example:
+#      endpoint: <your-endpoint-url>
+#
+#  service:
+#    pipelines:
+#      traces:
+#        exporters: [spanmetrics, otlphttp/example]
+
+exporters:
+  otlp/elastic:
+    # !!! Elastic APM https endpoint WITHOUT the "https://" prefix
+    endpoint: "YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX"
+    compression: none
+    headers:
+      Authorization: "Bearer YOUR_APM_SECRET_TOKEN"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [spanmetrics, otlp/elastic]
+    metrics:
+      receivers: [otlp, spanmetrics]
+      processors: [batch]
+      exporters: [otlp/elastic]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/elastic]

--- a/src/otelcollector/otelcol-elastic-config-extras.yaml
+++ b/src/otelcollector/otelcol-elastic-config-extras.yaml
@@ -1,22 +1,3 @@
-# Copyright The OpenTelemetry Authors
-# SPDX-License-Identifier: Apache-2.0
-
-# extra settings to be merged into OpenTelemetry Collector configuration
-# do not delete this file
-
-## Example configuration for sending data to your own OTLP HTTP backend
-## Note: the spanmetrics exporter must be included in the exporters array
-## if overriding the traces pipeline.
-##
-#  exporters:
-#    otlphttp/example:
-#      endpoint: <your-endpoint-url>
-#
-#  service:
-#    pipelines:
-#      traces:
-#        exporters: [spanmetrics, otlphttp/example]
-
 exporters:
   otlp/elastic:
     # !!! Elastic APM https endpoint WITHOUT the "https://" prefix

--- a/src/otelcollector/otelcol-elastic-config.yaml
+++ b/src/otelcollector/otelcol-elastic-config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+
+exporters:
+  debug:
+
+processors:
+  batch:
+
+connectors:
+  spanmetrics:


### PR DESCRIPTION
# Changes

Replace the Contrib collector with the Elastic distribution:

- [x] Docker compose
- [x] K8s

Note that the `elasticsearch exporter` has not been added yet to the configuration pipelines. For the moment, the configuration still uses the Otlp endpoint to forward all the logs, traces and metrics.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
