### PR TITLE
remove elasticsearch dynamic metrics index

### DIFF
--- a/kubernetes/elastic-helm/configmap-daemonset.yaml
+++ b/kubernetes/elastic-helm/configmap-daemonset.yaml
@@ -17,8 +17,6 @@ data:
         api_key: ${env:ELASTIC_API_KEY}
         logs_dynamic_index:
           enabled: true
-        metrics_dynamic_index:
-          enabled: true
         mapping:
           mode: ecs
     processors:


### PR DESCRIPTION
# Changes

The Onboarding flow does not enable the dynamic index for metrics. Seems to be the root issue for not having Processes in the "Top Processes" tab.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
