### PR TITLE
Enable specific feature flags for the k8s deployment

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,9 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
    ```
 
 ## Kubernetes
+
+In the provided Kubernetes deployment, we have enabled specific feature flags (`productCatalogFailure`, `adServiceManualGc` and `adServiceHighCpu`) designed to intentionally autogenerate errors. These are implemented to showcase error-handling mechanisms and demonstrate how Elastic Observability responds under various failure scenarios. Learn more about Demo's feature flags by visiting [this link](https://opentelemetry.io/docs/demo/feature-flags/).
+
 ### Prerequisites:
 - Create a Kubernetes cluster. There are no specific requirements, so you can create a local one, or use a managed Kubernetes cluster, such as [GKE](https://cloud.google.com/kubernetes-engine), [EKS](https://aws.amazon.com/eks/), or [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service).
 - Set up [kubectl](https://kubernetes.io/docs/reference/kubectl/).

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 
 ## Kubernetes
 
-In the provided Kubernetes deployment, we have enabled specific feature flags (`productCatalogFailure`, `adServiceManualGc` and `adServiceHighCpu`) designed to intentionally autogenerate errors. These are implemented to showcase error-handling mechanisms and demonstrate how Elastic Observability responds under various failure scenarios. Learn more about Demo's feature flags by visiting [this link](https://opentelemetry.io/docs/demo/feature-flags/).
+In the provided Kubernetes deployment, we have enabled specific feature flags (`paymentServiceFailure`, `adServiceManualGc` and `adServiceHighCpu`) designed to intentionally autogenerate errors. These are implemented to showcase error-handling mechanisms and demonstrate how Elastic Observability responds under various failure scenarios. Learn more about Demo's feature flags by visiting [this link](https://opentelemetry.io/docs/demo/feature-flags/).
 
 ### Prerequisites:
 - Create a Kubernetes cluster. There are no specific requirements, so you can create a local one, or use a managed Kubernetes cluster, such as [GKE](https://cloud.google.com/kubernetes-engine), [EKS](https://aws.amazon.com/eks/), or [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service).

--- a/kubernetes/elastic-helm/configmap-deployment.yaml
+++ b/kubernetes/elastic-helm/configmap-deployment.yaml
@@ -76,4 +76,121 @@ data:
       telemetry:
         metrics:
           address: ${env:MY_POD_IP}:8888
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-flagd-enabled-config
+  labels:
+    opentelemetry.io/name: opentelemetry-demo
+    app.kubernetes.io/instance: opentelemetry-demo
+    app.kubernetes.io/name: opentelemetry-demo
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  demo.flagd.json: |
+    {
+      "$schema": "https://flagd.dev/schema/v0/flags.json",
+      "flags": {
+        "productCatalogFailure": {
+          "description": "Fail product catalog service on a specific product",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "on"
+        },
+        "recommendationServiceCacheFailure": {
+          "description": "Fail recommendation service cache",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "adServiceManualGc": {
+          "description": "Triggers full manual garbage collections in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "on"
+        },
+        "adServiceHighCpu": {
+          "description": "Triggers high cpu load in the ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "on"
+        },
+        "adServiceFailure": {
+          "description": "Fail ad service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "kafkaQueueProblems": {
+          "description": "Overloads Kafka queue while simultaneously introducing a consumer side delay leading to a lag spike",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "cartServiceFailure": {
+          "description": "Fail cart service",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "paymentServiceFailure": {
+          "description": "Fail payment service charge requests",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "on"
+        },
+        "paymentServiceUnreachable": {
+          "description": "Payment service is unavailable",
+          "state": "ENABLED",
+          "variants": {
+            "on": true,
+            "off": false
+          },
+          "defaultVariant": "off"
+        },
+        "loadgeneratorFloodHomepage": {
+          "description": "Flood the frontend with a large amount of requests.",
+          "state": "ENABLED",
+          "variants": {
+            "on": 100,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        },
+        "imageSlowLoad": {
+          "description": "slow loading images in the frontend",
+          "state": "ENABLED",
+          "variants": {
+            "10sec": 10000,
+            "5sec": 5000,
+            "off": 0
+          },
+          "defaultVariant": "off"
+        }
+      }
+    }
 

--- a/kubernetes/elastic-helm/configmap-deployment.yaml
+++ b/kubernetes/elastic-helm/configmap-deployment.yaml
@@ -98,7 +98,7 @@ data:
             "on": true,
             "off": false
           },
-          "defaultVariant": "on"
+          "defaultVariant": "off"
         },
         "recommendationServiceCacheFailure": {
           "description": "Fail recommendation service cache",

--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -31,6 +31,13 @@ default:
     - name: OTEL_RESOURCE_ATTRIBUTES
       value: 'service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)'
 
+components:
+  flagd:
+    mountedConfigMaps:
+      - name: config
+        mountPath: /etc/flagd/
+        existingConfigMap: demo-flagd-enabled-config
+
 
 opentelemetry-collector:
   image:


### PR DESCRIPTION
# Changes

`paymentServiceFailure`, `adServiceManualGc` and `adServiceHighCpu` feature flags intentionally enabled to demostrate failure scenarios.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
