### PR TITLE
chore: bump elastic-agent to 8.16.0-SNAPSHOT

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -15,6 +15,7 @@ KAFKA_SERVICE_DOCKERFILE=./src/kafka/Dockerfile.elastic
 # *********************
 # Elastic Collector
 # *********************
-COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/beats/elastic-agent:8.15.0-SNAPSHOT
+COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/beats/elastic-agent:8.16.0-SNAPSHOT
 OTEL_COLLECTOR_CONFIG=./src/otelcollector/otelcol-elastic-config.yaml
 OTEL_COLLECTOR_CONFIG_EXTRAS=./src/otelcollector/otelcol-elastic-config-extras.yaml
+ELASTIC_AGENT_OTEL=true

--- a/docker-compose.minimal.yml
+++ b/docker-compose.minimal.yml
@@ -583,8 +583,7 @@ services:
         limits:
           memory: 200M
     restart: unless-stopped
-    command: ["otel", "--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
-    entrypoint: [ /usr/share/elastic-agent/elastic-agent ]
+    command: ["--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
     user: 0:0
     volumes:
       - ${HOST_FILESYSTEM}:/hostfs:ro
@@ -603,6 +602,7 @@ services:
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP
+      - ELASTIC_AGENT_OTEL
 
   # Prometheus
   prometheus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -693,8 +693,7 @@ services:
         limits:
           memory: 200M
     restart: unless-stopped
-    command: ["otel", "--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
-    entrypoint: [ /usr/share/elastic-agent/elastic-agent ]
+    command: ["--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
     user: 0:0
     volumes:
       - ${HOST_FILESYSTEM}:/hostfs:ro
@@ -713,6 +712,7 @@ services:
       - OTEL_COLLECTOR_HOST
       - OTEL_COLLECTOR_PORT_GRPC
       - OTEL_COLLECTOR_PORT_HTTP
+      - ELASTIC_AGENT_OTEL
 
   # Prometheus
   prometheus:

--- a/kubernetes/elastic-helm/configmap-daemonset.yaml
+++ b/kubernetes/elastic-helm/configmap-daemonset.yaml
@@ -9,6 +9,9 @@ metadata:
 
 data:
   relay: |
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     exporters:
       debug:
       elasticsearch:
@@ -253,6 +256,7 @@ data:
         extra_metadata_labels:
           - container.id
     service:
+      extensions: [health_check]
       pipelines:
         logs:
           receivers: [filelog]

--- a/kubernetes/elastic-helm/configmap-deployment.yaml
+++ b/kubernetes/elastic-helm/configmap-deployment.yaml
@@ -9,6 +9,9 @@ metadata:
 
 data:
   relay: |
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     connectors:
       spanmetrics: {}
     exporters:
@@ -18,7 +21,6 @@ data:
         compression: none
         headers:
           Authorization: Bearer ${env:ELASTIC_APM_SECRET_TOKEN}
-    extensions:
     processors:
       batch: {}
       resource:
@@ -42,6 +44,7 @@ data:
             endpoint: ${env:MY_POD_IP}:4318
     service:
       extensions:
+        - health_check
       pipelines:
         logs:
           exporters:

--- a/kubernetes/elastic-helm/daemonset.yaml
+++ b/kubernetes/elastic-helm/daemonset.yaml
@@ -11,24 +11,15 @@ presets:
 
 image:
   repository: docker.elastic.co/beats/elastic-agent
-  tag: 8.15.0-SNAPSHOT
-command:
-  name: "/usr/share/elastic-agent/elastic-agent"
-  extraArgs: ["otel"]
-livenessProbe:
-  httpGet:
-    port: 8888
-    path: metrics
-readinessProbe:
-  httpGet:
-    port: 8888
-    path: metrics
+  tag: 8.16.0-SNAPSHOT
 
 securityContext:
   runAsUser: 0
   runAsGroup: 0
 
 extraEnvs:
+  - name: ELASTIC_AGENT_OTEL
+    value: "true"
   - name: ELASTIC_ENDPOINT
     valueFrom:
       secretKeyRef:

--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -35,10 +35,7 @@ default:
 opentelemetry-collector:
   image:
     repository: docker.elastic.co/beats/elastic-agent
-    tag: 8.15.0-SNAPSHOT
-  command:
-    name: "/usr/share/elastic-agent/elastic-agent"
-    extraArgs: ["otel"]
+    tag: 8.16.0-SNAPSHOT
   mode: "deployment"
   presets:
     kubernetesAttributes:
@@ -49,6 +46,8 @@ opentelemetry-collector:
       enabled: true
 
   extraEnvs:
+    - name: ELASTIC_AGENT_OTEL
+      value: "true"
     - name: ELASTIC_APM_ENDPOINT
       valueFrom:
         secretKeyRef:
@@ -63,15 +62,6 @@ opentelemetry-collector:
   configMap:
     create: false
     existingName: elastic-otelcol-agent
-
-  livenessProbe:
-    httpGet:
-      port: 8888
-      path: metrics
-  readinessProbe:
-    httpGet:
-      port: 8888
-      path: metrics
 
 opensearch:
   enabled: false


### PR DESCRIPTION
# Changes

Use 8.16.0-SNAPSHOT version so we can remove the entrypoint override.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
