### PR TITLE
chore: disable inferred spans for Kafka service

### DIFF
--- a/src/kafka/Dockerfile.elastic
+++ b/src/kafka/Dockerfile.elastic
@@ -11,8 +11,6 @@ USER appuser
 
 ADD --chown=appuser:appuser https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=co.elastic.otel&a=elastic-otel-javaagent&v=LATEST /tmp/opentelemetry-javaagent.jar
 
-ENV OTEL_INFERRED_SPANS_ENABLED=true
-ENV ELASTIC_OTEL_SPAN_STACK_TRACE_MIN_DURATION=2
 ENV KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
 ENV KAFKA_CONTROLLER_QUORUM_VOTERS='1@0.0.0.0:9093'
 ENV KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER


### PR DESCRIPTION
# Changes

No traces are generated for the Kafka service

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
