### PR TITLE
Fix incorrect instructions for Node level metrics collection

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -70,7 +70,7 @@ In order to add Node level metrics collection we can run an additional Otel coll
      --from-literal=elastic_api_key='YOUR_ELASTICSEARCH_API_KEY'
    ```
    Don't forget to replace
-   - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (example: `1234567.us-west2.gcp.elastic-cloud.com:443`).
+   - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
    - `YOUR_ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
 
 2. Execute the following command to deploy the OpenTelemetry Collector to your Kubernetes cluster:


### PR DESCRIPTION
# Changes

Fixing incorect instructions on the node-level metrics. Omitting the `https`prefix didn't work when I tried to deploy.

## Merge Requirements

You may want to test this on your end. I was unable to get my GKE cluster working without adding the https prefix to the secret. 
