### PR TITLE
Disable spans on product catalog service in k8s

### DIFF
--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -11,8 +11,8 @@ default:
     - name: OTEL_K8S_NAMESPACE
       valueFrom:
         fieldRef:
-         apiVersion: v1
-         fieldPath: metadata.namespace
+          apiVersion: v1
+          fieldPath: metadata.namespace
     - name: OTEL_K8S_NODE_NAME
       valueFrom:
         fieldRef:
@@ -29,7 +29,7 @@ default:
           apiVersion: v1
           fieldPath: metadata.uid
     - name: OTEL_RESOURCE_ATTRIBUTES
-      value: 'service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)'
+      value: "service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)"
 
 components:
   frontendProxy:
@@ -42,7 +42,6 @@ components:
             - path: /
               pathType: Prefix
               port: 8080
-
 
 opentelemetry-collector:
   image:
@@ -92,6 +91,7 @@ opentelemetry-collector:
             services:
               - flagd
               - adservice
+              - productcatalogservice
       batch: {}
       resource:
         attributes:
@@ -101,7 +101,7 @@ opentelemetry-collector:
     receivers:
       httpcheck/frontendproxy:
         targets:
-        - endpoint: http://example-frontendproxy:8080
+          - endpoint: http://example-frontendproxy:8080
       otlp:
         protocols:
           grpc:
@@ -109,8 +109,8 @@ opentelemetry-collector:
           http:
             cors:
               allowed_origins:
-              - http://*
-              - https://*
+                - http://*
+                - https://*
             endpoint: ${env:MY_POD_IP}:4318
     service:
       extensions:
@@ -118,39 +118,38 @@ opentelemetry-collector:
       pipelines:
         logs:
           exporters:
-          - debug
-          - otlp/elastic
+            - debug
+            - otlp/elastic
           processors:
-          - batch
-          - resource
+            - batch
+            - resource
           receivers:
-          - otlp
+            - otlp
         metrics:
           exporters:
-          - otlp/elastic
-          - debug
+            - otlp/elastic
+            - debug
           processors:
-          - batch
-          - resource
+            - batch
+            - resource
           receivers:
-          - httpcheck/frontendproxy
-          - otlp
-          - spanmetrics
+            - httpcheck/frontendproxy
+            - otlp
+            - spanmetrics
         traces:
           exporters:
-          - otlp/elastic
-          - debug
-          - spanmetrics
+            - otlp/elastic
+            - debug
+            - spanmetrics
           processors:
-          - batch
-          - resource
-          - filter
+            - batch
+            - resource
+            - filter
           receivers:
-          - otlp
+            - otlp
       telemetry:
         metrics:
           address: ${env:MY_POD_IP}:8888
-
 
 opensearch:
   enabled: false


### PR DESCRIPTION
Disables traces in the product catalog service as documented already in the README