### PR TITLE
Improve serverless compat by no longer hardcoding `Bearer` auth

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-next-line -->
+
 # <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OTel logo" width="32"> :heavy_plus_sign: <img src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt601c406b0b5af740/620577381692951393fdf8d6/elastic-logo-cluster.svg" alt="OTel logo" width="32"> OpenTelemetry Demo with Elastic Observability
 
 The following guide describes how to setup the OpenTelemetry demo with Elastic Observability using [Docker compose](#docker-compose) or [Kubernetes](#kubernetes). This fork introduces several changes to the agents used in the demo:
@@ -10,39 +11,32 @@ The following guide describes how to setup the OpenTelemetry demo with Elastic O
 
 Additionally, the OpenTelemetry Contrib collector has also been changed to the [Elastic OpenTelemetry Collector distribution](https://github.com/elastic/elastic-agent/blob/main/internal/pkg/otel/README.md). This ensures a more integrated and optimized experience with Elastic Observability.
 
-## Docker compose
-
-1. Start a free trial on [Elastic Cloud](https://cloud.elastic.co/) and copy the `endpoint` and `secretToken` from the Elastic APM setup instructions in your Kibana.
-1. Open the file `src/otelcollector/otelcol-elastic-config-extras.yaml` in an editor and replace the following two placeholders:
-   - `YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX`: your Elastic APM endpoint (*without* `https://` prefix) that *must* also include the port (example: `1234567.apm.us-west2.gcp.elastic-cloud.com:443`).
-   - `YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token.
-1. Start the demo with the following command from the repository's root directory:
-   ```
-   make start
-   ```
-
 ## Kubernetes
+
 ### Prerequisites:
+
 - Create a Kubernetes cluster. There are no specific requirements, so you can create a local one, or use a managed Kubernetes cluster, such as [GKE](https://cloud.google.com/kubernetes-engine), [EKS](https://aws.amazon.com/eks/), or [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service).
 - Set up [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 - Set up [Helm](https://helm.sh/).
 
 ### Start the Demo
+
 1. Setup Elastic Observability on Elastic Cloud.
 1. Create a secret in Kubernetes with the following command.
    ```
    kubectl create secret generic elastic-secret \
      --from-literal=elastic_apm_endpoint='YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX' \
-     --from-literal=elastic_apm_secret_token='YOUR_APM_SECRET_TOKEN'
+     --from-literal=elastic_apm_secret_token='Bearer YOUR_APM_SECRET_TOKEN'
    ```
    Don't forget to replace
-   - `YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX`: your Elastic APM endpoint (*without* `https://` prefix) that *must* also include the port (example: `1234567.apm.us-west2.gcp.elastic-cloud.com:443`).
-   - `YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token
+   - `YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX`: your Elastic APM endpoint (_without_ `https://` prefix) that _must_ also include the port (example: `1234567.apm.us-west2.gcp.elastic-cloud.com:443`).
+   - `Bearer YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token. Note that in this branch you MUST place either `Bearer` or `ApiKey` in front of the token. On ESS / self-managed you will generally use `Bearer`, on serverless you will generally use `ApiKey`.
 1. Execute the following commands to deploy the OpenTelemetry demo to your Kubernetes cluster:
+
    ```
    # clone this repository
    git clone https://github.com/elastic/opentelemetry-demo
-   
+
    # switch to the kubernetes/elastic-helm directory
    cd kubernetes/elastic-helm
 
@@ -64,13 +58,16 @@ Kubernetes events collection with `kubernetesEvents`.
 In order to add Node level metrics collection we can run an additional Otel collector Daemonset with the following:
 
 1. Create a secret in Kubernetes with the following command.
+
    ```
    kubectl create secret generic elastic-secret-ds \
      --from-literal=elastic_endpoint='YOUR_ELASTICSEARCH_ENDPOINT' \
      --from-literal=elastic_api_key='YOUR_ELASTICSEARCH_API_KEY'
    ```
+
    Don't forget to replace
-   - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
+
+   - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (_with_ `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
    - `YOUR_ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
 
 2. Execute the following command to deploy the OpenTelemetry Collector to your Kubernetes cluster, in the same directory `kubernetes/elastic-helm` in this repository.
@@ -83,13 +80,17 @@ helm install otel-daemonset open-telemetry/opentelemetry-collector --values daem
 ## Explore and analyze the data With Elastic
 
 ### Service map
+
 ![Service map](service-map.png "Service map")
 
 ### Traces
+
 ![Traces](trace.png "Traces")
 
 ### Correlation
+
 ![Correlation](correlation.png "Correlation")
 
 ### Logs
+
 ![Logs](logs.png "Logs")

--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -71,7 +71,7 @@ opentelemetry-collector:
         endpoint: ${env:ELASTIC_APM_ENDPOINT}
         compression: none
         headers:
-          Authorization: Bearer ${env:ELASTIC_APM_SECRET_TOKEN}
+          Authorization: ${env:ELASTIC_APM_SECRET_TOKEN}
     processors:
       batch: {}
       resource:


### PR DESCRIPTION
This PR changes the demo to no longer hardcode `Bearer` auth. In serverless `ApiKey` auth is more commonly used.