### PR TITLE
Change the authentication method to work with Elastic Serverless

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -37,7 +37,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
    ```
    Don't forget to replace
    - `YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX`: your Elastic APM endpoint (*without* `https://` prefix) that *must* also include the port (example: `1234567.apm.us-west2.gcp.elastic-cloud.com:443`).
-   - `YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token
+   - `YOUR_APM_SECRET_TOKEN`: your Elastic APM secret token, include the Bearer or ApiKey but not the "Authorization=" part e.g. Bearer XXXXXX or ApiKey XXXXX
 1. Execute the following commands to deploy the OpenTelemetry demo to your Kubernetes cluster:
    ```
    # clone this repository

--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -71,7 +71,7 @@ opentelemetry-collector:
         endpoint: ${env:ELASTIC_APM_ENDPOINT}
         compression: none
         headers:
-          Authorization: Bearer ${env:ELASTIC_APM_SECRET_TOKEN}
+          Authorization: ${env:ELASTIC_APM_SECRET_TOKEN}
     processors:
       batch: {}
       resource:

--- a/src/otelcollector/otelcol-elastic-config-extras.yaml
+++ b/src/otelcollector/otelcol-elastic-config-extras.yaml
@@ -4,7 +4,7 @@ exporters:
     endpoint: "YOUR_APM_ENDPOINT_WITHOUT_HTTPS_PREFIX"
     compression: none
     headers:
-      Authorization: "Bearer YOUR_APM_SECRET_TOKEN"
+      Authorization: "YOUR_APM_SECRET_TOKEN"
 
 service:
   pipelines:


### PR DESCRIPTION
This is a simple change to remove the "Bearer" hardcoding so that the otel demo works properly for serverless, the README has also been updated to reflect this change. 