### PR TITLE
Auto sources .env file if it exists

### DIFF
--- a/elastic-setup
+++ b/elastic-setup
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "ATTN: This script has moved to ./scripts/rca-demo/setup"

--- a/scripts/rca-demo/setup
+++ b/scripts/rca-demo/setup
@@ -37,6 +37,14 @@ die () {
 
 title "Checking environment for $APP_NAME..."
 
+# Load local user .env file
+ENV_FILE="./.env"
+if [ -f $ENV_FILE ]; then
+	echo "Sourcing env vars from $ENV_FILE ..."
+  source $ENV_FILE
+fi
+
+
 # Check tools
 tools=("helm" "kubectl" "minikube" "node" "npx")
 for tool in ${tools[@]}; do

--- a/trigger-demo-scenario
+++ b/trigger-demo-scenario
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "ATTN: This script has moved to be inside ./scripts/rca-demo"


### PR DESCRIPTION
# Summary

If the new ./scripts/rca-demo/.env file has been created (copied from the .env.example file), the setup script will auto-source it. 

Also, the old locations for the elastic-setup and trigger-demo-scenario scripts now tell you where they have been moved.

