### PR TITLE
Makes synthetics requirements optional

### DIFF
--- a/scripts/rca-demo/.env.example
+++ b/scripts/rca-demo/.env.example
@@ -53,7 +53,18 @@ export OTEL_DEMO_ES_ENDPOINT=""
 # API key, visit https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
 export OTEL_DEMO_ES_API_KEY=""
 
+# SYNTHETICS_API_KEY
+#
+# DO NOT SET THIS if you don't want to set up synthetics. Leave it as an empty string
+# to opt out of all synthetics set up.
+
+# Otherwise, get a synthetics API key from the "Project API Key" 
+# page in your Synthetics Kibana app
+export SYNTHETICS_API_KEY="YOURSYNTHETICSAPIKEYI"
+
 # KIBANA_URL
+#
+# Only required if opting into synthetics set up.
 #
 # URL where your connected Kibana is running. If you are running Kibana locally,
 # this will probabably be http://host.minikube.internal:5601/basepath or similar.
@@ -63,10 +74,14 @@ export KIBANA_URL=""
 
 # KIBANA_API_KEY
 #
+# Only required if opting into synthetics set up.
+#
 # Explanation TBA
-export KIBANA_API_KEY="YOURAPIKEY"
+export KIBANA_API_KEY=""
 
 # OTEL_DEMO_FLEET_URL
+#
+# Only required if opting into synthetics set up.
 #
 # Create a fleet policy (for a synthetics private location) and go through the "add agent" flow for it. 
 # Within the policy go through the add agent flow and get these values from there. 
@@ -74,17 +89,16 @@ export KIBANA_API_KEY="YOURAPIKEY"
 # Note: for local dev, you will need to set up a Fleet SERVER before you can extract the agent setup values.
 #
 # Fuller explanation TBA
-export OTEL_DEMO_FLEET_URL="https://FLEET_URL"
+export OTEL_DEMO_FLEET_URL=""
 
 # OTEL_DEMO_FLEET_ENROLLMENT_TOKEN
 #
-# Explanation TBA
-export OTEL_DEMO_FLEET_ENROLLMENT_TOKEN="YOURTOKEN"
-
-# SYNTHETICS_API_KEY
+# Only required if opting into synthetics set up.
 #
-# Get the synthetics API key from the "Project API Key" page in the Synthetics Kibana app
-export SYNTHETICS_API_KEY="YOURSYNTHETICSAPIKEYI"
+# Explanation TBA
+export OTEL_DEMO_FLEET_ENROLLMENT_TOKEN=""
+
+
 
 # SYNTHETICS_PRIVATE_LOCATION
 #

--- a/scripts/rca-demo/setup
+++ b/scripts/rca-demo/setup
@@ -73,21 +73,26 @@ if [ -z "${OTEL_DEMO_ES_API_KEY}" ]; then
   die "You must set OTEL_DEMO_ES_API_KEY"
 fi
 
-if [ -z "${OTEL_DEMO_FLEET_URL}" ]; then
-  die "You must set OTEL_DEMO_FLEET_URL"
-fi
-
-if [ -z "${OTEL_DEMO_FLEET_ENROLLMENT_TOKEN}" ]; then
-  die "You must set OTEL_DEMO_FLEET_ENROLLMENT_TOKEN"
-fi
-
 if [ -z "${SYNTHETICS_API_KEY}" ]; then
-  die "You must set SYNTHETICS_API_KEY"
+	echo "No SYNTHETICS_API_KEY set, will skip synthetics setup"
+else
+  echo "By providing a SYNTHETICS_API_KEY value, you are opting IN to synthetics setup"
+	echo "Please remove this env var or set it to \"\" to opt out."
+
+	if [ -z "${KIBANA_URL}" ]; then
+		die "[Synthetics Requirement] You must set KIBANA_URL"
+	fi
+
+	if [ -z "${OTEL_DEMO_FLEET_URL}" ]; then
+		die "[Synthetics Requirement] You must set OTEL_DEMO_FLEET_URL"
+	fi
+
+	if [ -z "${OTEL_DEMO_FLEET_ENROLLMENT_TOKEN}" ]; then
+		die "[Synthetics Requirement] You must set OTEL_DEMO_FLEET_ENROLLMENT_TOKEN"
+	fi
 fi
 
-if [ -z "${KIBANA_URL}" ]; then
-  die "You must set KIBANA_URL"
-fi
+
 
 if minikube status | grep -q "Running"; then
 	title "Minikube is already running, skipping..."
@@ -118,10 +123,9 @@ kubectl create secret generic elastic-secret-ds \
   --from-literal=fleet_url="$OTEL_DEMO_FLEET_URL" \
   --from-literal=fleet_enrollment_token="$OTEL_DEMO_FLEET_ENROLLMENT_TOKEN"
 
-title "Installing/Upgrading helm charts for $APP_NAME..."
-pushd kubernetes/elastic-helm
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-helm repo update open-telemetry
+pushd_helm_dir () {
+	pushd	kubernetes/elastic-helm
+}
 
 # Install or upgrade helm chart
 helminst () {
@@ -136,10 +140,19 @@ helminst () {
 	helm $hcommand $@
 }
 
+title "Installing/Upgrading helm charts for $APP_NAME..."
+
+pushd_helm_dir
+
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update open-telemetry
+
 title "Installing $APP_NAME helm chart"
 helminst $APP_NAME -f deployment.yaml $1 open-telemetry/opentelemetry-demo
 title "Installing daemonset helm chart"
 helminst otel-daemonset open-telemetry/opentelemetry-collector --values daemonset.yaml  
+
+popd
 
 # Check if dns entry for otel-demo.internal exists
 if ! grep -q "otel-demo.internal" /etc/hosts
@@ -158,16 +171,18 @@ while kubectl get pods --all-namespaces | grep -q -E "ContainerCreating|PodIniti
 done
 
 title "Installing nginx ingress"
+pushd_helm_dir
 helminst nginx-ingress ./ingress
+popd
 
 # If synthetics is configured
 if [ -n "${SYNTHETICS_API_KEY}" ]; then
 	title "Installing synthetics agent helm chart"
+	pushd_helm_dir
 	helminst otel-synthetics-agent ./otel-synthetics
-
-	
-	title "Pushing Synthetics project..."
 	popd
+
+	title "Pushing Synthetics project..."
 	cd synthetic-monitors
 	npm install
 	yes | npx @elastic/synthetics push . --params '{"url": "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local"}'


### PR DESCRIPTION
@andrewvc earlier today made the actual installation of synthetics dependent on the SYNTHETICS_API_KEY value being non-empty. These changes adjust the corresponding .env.example documentation as well as the gated requirements checking during the setup script run.

Before these changes, the setup script will fail if you don't set all of the env vars, even ones only needed for synthetics setup.