### PR TITLE
Pass service name as argument to version release annotation script

### DIFF
--- a/scripts/rca-demo/create-release-annotation
+++ b/scripts/rca-demo/create-release-annotation
@@ -37,9 +37,21 @@ if [ -z "${KIBANA_API_KEY}" ]; then
   die "You must set KIBANA_API_KEY to a valid KIBANA API KEY"
 fi
 
-action=$1
+if [[ "$1" != -* ]]; then
+    action="$1"
+    shift
+fi
 
-service_name="cartservice"
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -s) service_name="$2"; shift ;;
+    esac
+    shift
+done
+
+if [[ -z "$service_name" ]]; then
+  die "You must specify service name using -s option"
+fi
 
 release_timestamp=$(date -u -v-5M +"%Y-%m-%dT%H:%M:%SZ")
 new_service_version="2.0.0"

--- a/scripts/rca-demo/trigger-demo-scenario
+++ b/scripts/rca-demo/trigger-demo-scenario
@@ -11,6 +11,7 @@ echo "Replacing cart service command"
 if [ "$action" == "restore" ]; then
 	echo "Restoring original command"
 	kubectl patch deployment my-otel-demo-cartservice --type='json' -p='[{"op": "remove", "path": "/spec/template/spec/containers/0/command"}]'
+	./scripts/rca-demo/create-release-annotation restore -s cartservice
 	exit 0
 else
 	echo "Scale the my-otel-demo-cartservice deployment to 0"
@@ -20,4 +21,5 @@ else
 	kubectl patch deployment my-otel-demo-cartservice --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/command", "value": ["/bin/sh", "-c", "echo Could not start, bad entrypoint! >&2"]}]'
 	echo "Scale back up"
 	kubectl scale deployment my-otel-demo-cartservice --replicas=1
+	./scripts/rca-demo/create-release-annotation -s cartservice
 fi


### PR DESCRIPTION
Changes related to version release annotation script:

- Pass service name as argument to `create-release-annotation` script
- Call `create-release-annotation` script with `-s cartservice` in `trigger-demo-scenario` script as this script uses `cartservice` (If needed, we can make `trigger-demo-scenario` script to accept service name as argument)

### Usage
- Run the scripts from `opentelemetry-demo` folder

```
# create version release annotation
./scripts/rca-demo/create-release-annotation -s checkoutservice

# create version rollback annotation
./scripts/rca-demo/create-release-annotation restore -s checkoutservice

# trigger failure scenario and version release annotation for cartservice
./scripts/rca-demo/trigger-demo-scenario

# restore failure scenario and trigger version rollback annotation for cartservice
./scripts/rca-demo/trigger-demo-scenario restore
```