### PR TITLE
Removes body text alias mapping change because OTEL demo updated

### DIFF
--- a/scripts/rca-demo/post-setup
+++ b/scripts/rca-demo/post-setup
@@ -71,8 +71,8 @@ echo -e "\n"
 # Update mappings in ES
 # NOTE: this will fail if the data stream is not created
 # TODO: Update the component template also, and just swallow errors on this call
-title "Attempting to add message alias for otel logs"
-curl -X PUT "$OTEL_DEMO_ES_ENDPOINT/logs-*otel*/_mapping" -H "Authorization: ApiKey $OTEL_DEMO_ES_API_KEY" -H "Content-Type: application/json" -d @$SCRIPTS_DIR/data/mapping-message-alias.json
+title "Skipping message alias for otel logs, not needed anymore"
+# curl -X PUT "$OTEL_DEMO_ES_ENDPOINT/logs-*otel*/_mapping" -H "Authorization: ApiKey $OTEL_DEMO_ES_API_KEY" -H "Content-Type: application/json" -d @$SCRIPTS_DIR/data/mapping-message-alias.json
 
 echo -e "\n"
 


### PR DESCRIPTION
# Changes

The OTel demo seems to have updated so that its otel logs no longer ship with `body_text`, which we had to account for before, but now with `body.text`, which our mappings already account for. So the post-setup script will break our ES env with this mapping change, if the data is flowing in with body.text. We no longer need this mapping update, unless you're running an old version of the OTel demo services. 

If you still see body_text in your logs-*otel* documents, kill minikube and re-run the `setup` script, and it should start sending documents with body.text instead. 