### PR TITLE
Fix typo for LOCUST_HOST

### DIFF
--- a/kubernetes/elastic-helm/deployment.yaml
+++ b/kubernetes/elastic-helm/deployment.yaml
@@ -50,7 +50,7 @@ components:
   loadgenerator:
     envOverrides:
       - name: LOCUST_HOST
-        value: "http:/ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
+        value: "http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80"
 
 opentelemetry-collector:
   image:


### PR DESCRIPTION
This fixes a typo in the loadgenerator deployment config, that was causing all tasks for the WebsiteUser to fail (the ones for WebsiteBrowserUser are working). Looks like that gives us logs for at least 6 more services:

- `accountingservice`
- `emailservice`
- `paymentservice`
- `quoteservice`
- `shippingservice`
- `valkey`