### PR TITLE
Add support for Managed Ingest Endpoint

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -18,7 +18,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
    - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
    - `YOUR_ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
 
-### Elastic Cloud Native OpenTelemetry Endpoint
+### Managed Ingest Endpoint
 1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
 2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace `.apm` with `.ingest`.
 3. Click "Create an API Key" to create one.
@@ -90,7 +90,7 @@ helm install otel-daemonset open-telemetry/opentelemetry-collector --values daem
 ```
 </details>
 
-### Elastic Cloud Native OpenTelemetry Endpoint
+### Managed Ingest Endpoint
 
 <details>
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -20,11 +20,11 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 
 ### Elastic Cloud Native OpenTelemetry Endpoint
 1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
-2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace .apm with .ingest
-3. Click "Create an API Key" to create one
+2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace `.apm` with `.ingest`.
+3. Click "Create an API Key" to create one.
 4. Open the file `src/otel-collector/otelcol-elastic-otlp-config.yaml` in an editor and replace all occurrences the following two placeholders:
-   - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT URL.
-   - `YOUR_OTEL_EXPORTER_OTLP_TOKEN`: your Elasticsearch API Key
+   - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT_URL.
+   - `YOUR_OTEL_EXPORTER_OTLP_TOKEN`: your Elastic OTLP endpoint token. This is what comes after `ApiKey=`.
 5. Open `.env.override` and add `src/otel-collector/otelcol-elastic-otlp-config.yaml` as `OTEL_COLLECTOR_CONFIG`  
 6. Start the demo with the following command from the repository's root directory:
    ```
@@ -37,8 +37,11 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Set up [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 - Set up [Helm](https://helm.sh/).
 
+### Elasticsearch exporter
+<details>
 
-### Start the Demo (Kubernetes deployment)
+#### Start the Demo (Kubernetes deployment)
+
 1. Setup Elastic Observability on Elastic Cloud.
 2. Create a secret in Kubernetes with the following command.
    ```
@@ -85,6 +88,63 @@ To deploy the EDOT Collector to your Kubernetes cluster, ensure the `elastic-sec
 # deploy the Elastic OpenTelemetry collector distribution through helm install
 helm install otel-daemonset open-telemetry/opentelemetry-collector --values daemonset.yaml
 ```
+</details>
+
+### Elastic Cloud Native OpenTelemetry Endpoint
+
+<details>
+
+#### Start the Demo (Kubernetes deployment)
+
+1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
+2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace `.apm` with `.ingest`.
+3. Click "Create an API Key" to create one..
+4. Create a secret in Kubernetes with the following command.
+   ```
+   kubectl create secret generic elastic-secret-otel \
+   --from-literal=elastic_otlp_endpoint='YOUR_ELASTIC_OTLP_ENDPOINT' \
+   --from-literal=elastic_otlp_token='YOUR_ELASTIC_OTLP_TOKEN'
+   ```
+   Don't forget to replace
+   - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT URL (replace `.apm` with `.ingest`).
+   - `YOUR_OTEL_EXPORTER_OTLP_TOKEN`: your Elastic OTLP endpoint token. This is what comes after `ApiKey=` after clicking on "Create API Key" on step 3.
+5. Execute the following commands to deploy the OpenTelemetry demo to your Kubernetes cluster:
+   ```
+   # clone this repository
+   git clone https://github.com/elastic/opentelemetry-demo
+
+   # switch to the kubernetes/elastic-helm directory
+   cd opentelemetry-demo/kubernetes/elastic-helm
+
+   # !(when running it for the first time) add the open-telemetry Helm repostiroy
+   helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+
+   # !(when an older helm open-telemetry repo exists) update the open-telemetry helm repo
+   helm repo update open-telemetry
+
+   # deploy the demo through helm install
+   helm install -f deploymen-otlp.yaml my-otel-demo open-telemetry/opentelemetry-demo
+   ```
+
+Additionally, this EDOT Collector configuration includes the following components for comprehensive Kubernetes monitoring:
+  - [K8s Objects Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver): Captures detailed information about Kubernetes objects.
+  - [K8s Cluster Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver): Collects metrics and metadata about the overall cluster state.
+
+#### Kubernetes monitoring (daemonset)
+
+The `daemonset` EDOT collector is configured with the components to monitor node-level metrics and logs, ensuring detailed insights into individual Kubernetes nodes:
+
+- [Host Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetrics): Collects system-level metrics such as CPU, memory, and disk usage from the host.
+- [Kubelet Stats Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstats): Gathers pod and container metrics directly from the kubelet.
+- [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelog): Ingests and parses log files from nodes, providing detailed log analysis.
+
+To deploy the EDOT Collector to your Kubernetes cluster, ensure the `elastic-secret-otel` Kubernetes secret is created (if it doesn't already exist). Then, run the following command from the `kubernetes/elastic-helm` directory in this repository.
+
+```
+# deploy the Elastic OpenTelemetry collector distribution through helm install
+helm install otel-daemonset open-telemetry/opentelemetry-collector --values daemonset-otlp.yaml
+```
+</details>
 
 #### Kubernetes architecture diagram
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -123,7 +123,7 @@ helm install otel-daemonset open-telemetry/opentelemetry-collector --values daem
    helm repo update open-telemetry
 
    # deploy the demo through helm install
-   helm install -f deploymen-otlp.yaml my-otel-demo open-telemetry/opentelemetry-demo
+   helm install -f deployment-otlp.yaml my-otel-demo open-telemetry/opentelemetry-demo
    ```
 
 Additionally, this EDOT Collector configuration includes the following components for comprehensive Kubernetes monitoring:

--- a/.github/README.md
+++ b/.github/README.md
@@ -98,7 +98,7 @@ helm install otel-daemonset open-telemetry/opentelemetry-collector --values daem
 
 1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
 2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace `.apm` with `.ingest`.
-3. Click "Create an API Key" to create one..
+3. Click "Create an API Key" to create one.
 4. Create a secret in Kubernetes with the following command.
    ```
    kubectl create secret generic elastic-secret-otel \

--- a/.github/README.md
+++ b/.github/README.md
@@ -12,11 +12,21 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 
 ## Docker compose
 
+### Elasticsearch exporter (default)
 1. Start a free trial on [Elastic Cloud](https://cloud.elastic.co/) and copy the `Elasticsearch endpoint` and the `API Key` from the `Help -> Connection details` drop down instructions in your Kibana. These variables will be used by the [elasticsearch exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter#elasticsearch-exporter) to authenticate and transmit data to your Elasticsearch instance.
 2. Open the file `src/otel-collector/otelcol-elastic-config.yaml` in an editor and replace all occurrences the following two placeholders:
    - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
    - `YOUR_ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
-3. Start the demo with the following command from the repository's root directory:
+
+### Elastic Cloud Native OpenTelemetry Endpoint
+1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
+2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace .apm with .ingest
+3. Click "Create an API Key" to create one
+4. Open the file `src/otel-collector/otelcol-elastic-otlp-config.yaml` in an editor and replace all occurrences the following two placeholders:
+   - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT URL.
+   - `YOUR_OTEL_EXPORTER_OTLP_TOKEN`: your Elasticsearch API Key
+5. Open `.env.override` and add `src/otel-collector/otelcol-elastic-otlp-config.yaml` as `OTEL_COLLECTOR_CONFIG`  
+6. Start the demo with the following command from the repository's root directory:
    ```
    make start
    ```

--- a/kubernetes/elastic-helm/daemonset-otlp.yaml
+++ b/kubernetes/elastic-helm/daemonset-otlp.yaml
@@ -1,0 +1,357 @@
+mode: daemonset
+presets:
+  logsCollection:
+    enabled: true
+  hostMetrics:
+    enabled: true
+  kubeletMetrics:
+    enabled: true
+  kubernetesAttributes:
+    enabled: true
+
+image:
+  repository: docker.elastic.co/beats/elastic-agent
+  tag: 8.17.2
+
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+
+extraEnvs:
+  # Work around for open /mounts error: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990
+  - name: HOST_PROC_MOUNTINFO
+    value: ""
+  - name: ELASTIC_AGENT_OTEL
+    value: "true"
+  - name: ELASTIC_ENDPOINT
+    valueFrom:
+      secretKeyRef:
+        name: elastic-secret-otel
+        key: elastic_endpoint
+  - name: ELASTIC_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: elastic-secret-otel
+        key: elastic_api_key
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+
+# kubeletstats additional rules for Node metrics
+clusterRole:
+  create: true
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - nodes/proxy
+      verbs:
+        - get
+    - apiGroups:
+        - ""
+      resources:
+        - nodes
+      verbs:
+        - get
+        - watch
+        - list
+
+config:
+  extensions:
+    health_check:
+      endpoint: ${env:MY_POD_IP}:13133
+  exporters:
+    debug:
+      verbosity: basic
+    elasticsearch/ecs:
+      endpoints:
+      - ${env:ELASTIC_ENDPOINT}
+      api_key: ${env:ELASTIC_API_KEY}
+      logs_dynamic_index:
+        enabled: true
+      metrics_dynamic_index:
+        enabled: true
+      mapping:
+        mode: ecs
+    elasticsearch/otel:
+      endpoints:
+      - ${env:ELASTIC_ENDPOINT}
+      api_key: ${env:ELASTIC_API_KEY}
+      logs_dynamic_index:
+        enabled: true
+      metrics_dynamic_index:
+        enabled: true
+      mapping:
+        mode: otel
+  processors:
+    batch: {}
+    batch/metrics:
+      # explicitly set send_batch_max_size to 0, as splitting metrics requests may cause version_conflict_engine_exception in TSDB
+      send_batch_max_size: 0
+      timeout: 1s
+    elasticinframetrics:
+      add_system_metrics: true
+      add_k8s_metrics: true
+      drop_original: true
+    resourcedetection/cluster:
+      detectors: [env, eks, gcp, aks, eks, k8snode]
+      timeout: 15s
+      override: true
+      k8snode:
+        auth_type: serviceAccount
+      eks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+      aks:
+        resource_attributes:
+          k8s.cluster.name:
+            enabled: true
+    resource/k8s: # Resource attributes tailored for services within Kubernetes.
+      attributes:
+        - key: service.name # Set the service.name resource attribute based on the well-known app.kubernetes.io/name label
+          from_attribute: app.label.name
+          action: insert
+        - key: service.name # Set the service.name resource attribute based on the k8s.container.name attribute
+          from_attribute: k8s.container.name
+          action: insert
+        - key: app.label.name # Delete app.label.name attribute previously used for service.name
+          action: delete
+        - key: service.version # Set the service.version resource attribute based on the well-known app.kubernetes.io/version label
+          from_attribute: app.label.version
+          action: insert
+        - key: app.label.version # Delete app.label.version attribute previously used for service.version
+          action: delete
+    resource/hostname:
+      attributes:
+        - key: host.name
+          from_attribute: k8s.node.name
+          action: upsert
+    attributes/dataset:
+      actions:
+        - key: event.dataset
+          from_attribute: data_stream.dataset
+          action: upsert
+    resource/cloud:
+      attributes:
+        - key: cloud.instance.id
+          from_attribute: host.id
+          action: insert
+    resource/demo:
+      attributes:
+        - key: deployment.environment
+          value: "opentelemetry-demo"
+          action: upsert
+    resource/process:
+      attributes:
+        - key: process.executable.name
+          action: delete
+        - key: process.executable.path
+          action: delete
+    resourcedetection/system:
+      detectors: ["system", "ec2"]
+      system:
+        hostname_sources: [ "os" ]
+        resource_attributes:
+          host.name:
+            enabled: true
+          host.id:
+            enabled: false
+          host.arch:
+            enabled: true
+          host.ip:
+            enabled: true
+          host.mac:
+            enabled: true
+          host.cpu.vendor.id:
+            enabled: true
+          host.cpu.family:
+            enabled: true
+          host.cpu.model.id:
+            enabled: true
+          host.cpu.model.name:
+            enabled: true
+          host.cpu.stepping:
+            enabled: true
+          host.cpu.cache.l2.size:
+            enabled: true
+          os.description:
+            enabled: true
+          os.type:
+            enabled: true
+      ec2:
+        resource_attributes:
+          host.name:
+            enabled: false
+          host.id:
+            enabled: true
+    k8sattributes:
+      filter:
+        node_from_env_var: K8S_NODE_NAME
+      passthrough: false
+      pod_association:
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+        - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+        - sources:
+            - from: connection
+      extract:
+        metadata:
+          - "k8s.namespace.name"
+          - "k8s.deployment.name"
+          - "k8s.statefulset.name"
+          - "k8s.daemonset.name"
+          - "k8s.cronjob.name"
+          - "k8s.job.name"
+          - "k8s.node.name"
+          - "k8s.pod.name"
+          - "k8s.pod.uid"
+          - "k8s.pod.start_time"
+        labels:
+          - tag_name: app.label.component
+            key: app.kubernetes.io/component
+            from: pod
+  receivers:
+    otlp: null
+    jaeger: null
+    prometheus: null
+    zipkin: null
+    filelog:
+      retry_on_failure:
+        enabled: true
+      start_at: end
+      exclude:
+      # exlude collector logs
+      - /var/log/pods/*/opentelemetry-collector/*.log
+      include:
+      - /var/log/pods/*/*/*.log
+      include_file_name: false
+      include_file_path: true
+      operators:
+      - id: container-parser
+        type: container
+    hostmetrics:
+      collection_interval: 10s
+      root_path: /hostfs
+      scrapers:
+        cpu:
+          metrics:
+            system.cpu.utilization:
+              enabled: true
+            system.cpu.logical.count:
+              enabled: true
+        memory:
+          metrics:
+            system.memory.utilization:
+              enabled: true
+        process:
+          mute_process_exe_error: true
+          mute_process_io_error: true
+          mute_process_user_error: true
+          metrics:
+            process.threads:
+              enabled: true
+            process.open_file_descriptors:
+              enabled: true
+            process.memory.utilization:
+              enabled: true
+            process.disk.operations:
+              enabled: true
+        network:
+        processes:
+        load:
+        disk:
+        filesystem:
+          exclude_mount_points:
+            mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+            match_type: regexp
+          exclude_fs_types:
+            fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+            match_type: strict
+    kubeletstats:
+      auth_type: serviceAccount
+      collection_interval: 20s
+      endpoint: ${env:K8S_NODE_NAME}:10250
+      node: '${env:K8S_NODE_NAME}'
+      # Required to work for all CSPs without an issue
+      insecure_skip_verify: true
+      k8s_api_config:
+        auth_type: serviceAccount
+      metrics:
+        k8s.pod.memory.node.utilization:
+          enabled: true
+        k8s.pod.cpu.node.utilization:
+          enabled: true
+        k8s.container.cpu_limit_utilization:
+          enabled: true
+        k8s.pod.cpu_limit_utilization:
+          enabled: true
+        k8s.container.cpu_request_utilization:
+          enabled: true
+        k8s.container.memory_limit_utilization:
+          enabled: true
+        k8s.pod.memory_limit_utilization:
+          enabled: true
+        k8s.container.memory_request_utilization:
+          enabled: true
+        k8s.node.uptime:
+          enabled: true
+        k8s.node.cpu.usage:
+          enabled: true
+        k8s.pod.cpu.usage:
+          enabled: true
+      extra_metadata_labels:
+        - container.id
+  service:
+    extensions: [health_check]
+    pipelines:
+      logs:
+        receivers: [filelog]
+        processors: [batch, k8sattributes, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud]
+        exporters: [debug, elasticsearch/otel]
+      metrics:
+        receivers: [hostmetrics, kubeletstats]
+        processors: [batch/metrics, k8sattributes, elasticinframetrics, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud, attributes/dataset, resource/process]
+        exporters: [debug, elasticsearch/ecs]
+      metrics/otel:
+        receivers: [kubeletstats]
+        processors: [batch/metrics, k8sattributes, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud]
+        exporters: [debug, elasticsearch/otel]
+      traces: null
+    telemetry:
+      metrics:
+        address: ${env:MY_POD_IP}:8888

--- a/kubernetes/elastic-helm/daemonset-otlp.yaml
+++ b/kubernetes/elastic-helm/daemonset-otlp.yaml
@@ -23,16 +23,16 @@ extraEnvs:
     value: ""
   - name: ELASTIC_AGENT_OTEL
     value: "true"
-  - name: ELASTIC_ENDPOINT
+  - name: ELASTIC_OTLP_ENDPOINT
     valueFrom:
       secretKeyRef:
         name: elastic-secret-otel
-        key: elastic_endpoint
-  - name: ELASTIC_API_KEY
+        key: elastic_otlp_endpoint
+  - name: ELASTIC_OTLP_TOKEN
     valueFrom:
       secretKeyRef:
         name: elastic-secret-otel
-        key: elastic_api_key
+        key: elastic_otlp_token
   - name: K8S_NODE_NAME
     valueFrom:
       fieldRef:
@@ -64,26 +64,10 @@ config:
   exporters:
     debug:
       verbosity: basic
-    elasticsearch/ecs:
-      endpoints:
-      - ${env:ELASTIC_ENDPOINT}
-      api_key: ${env:ELASTIC_API_KEY}
-      logs_dynamic_index:
-        enabled: true
-      metrics_dynamic_index:
-        enabled: true
-      mapping:
-        mode: ecs
-    elasticsearch/otel:
-      endpoints:
-      - ${env:ELASTIC_ENDPOINT}
-      api_key: ${env:ELASTIC_API_KEY}
-      logs_dynamic_index:
-        enabled: true
-      metrics_dynamic_index:
-        enabled: true
-      mapping:
-        mode: otel
+    otlphttp/elastic:
+      endpoint: "${env:ELASTIC_OTLP_ENDPOINT}"
+      headers:
+        Authorization: "ApiKey ${env:ELASTIC_OTLP_TOKEN}"
   processors:
     batch: {}
     batch/metrics:
@@ -342,15 +326,15 @@ config:
       logs:
         receivers: [filelog]
         processors: [batch, k8sattributes, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud]
-        exporters: [debug, elasticsearch/otel]
+        exporters: [debug, otlphttp/elastic]
       metrics:
         receivers: [hostmetrics, kubeletstats]
         processors: [batch/metrics, k8sattributes, elasticinframetrics, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud, attributes/dataset, resource/process]
-        exporters: [debug, elasticsearch/ecs]
+        exporters: [debug, otlphttp/elastic]
       metrics/otel:
         receivers: [kubeletstats]
         processors: [batch/metrics, k8sattributes, resourcedetection/cluster, resource/hostname, resource/demo, resource/k8s, resource/cloud]
-        exporters: [debug, elasticsearch/otel]
+        exporters: [debug, otlphttp/elastic]
       traces: null
     telemetry:
       metrics:

--- a/kubernetes/elastic-helm/deployment-otlp.yaml
+++ b/kubernetes/elastic-helm/deployment-otlp.yaml
@@ -1,0 +1,578 @@
+default:
+  image:
+    repository: ghcr.io/elastic/opentelemetry-demo
+    tag: 2.0.1
+  envOverrides:
+    - name: OTEL_SERVICE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.labels['app.kubernetes.io/component']
+    - name: OTEL_K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+         apiVersion: v1
+         fieldPath: metadata.namespace
+    - name: OTEL_K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+    - name: OTEL_K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: OTEL_K8S_POD_UID
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.uid
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: 'service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME)'
+
+
+opentelemetry-collector:
+  image:
+    repository: docker.elastic.co/beats/elastic-agent
+    tag: 8.17.2
+  mode: "deployment"
+  useGOMEMLIMIT: false
+  resources:
+    # The high resource limits set here are due to the usage of the lsminterval processor.
+    # The # [LSM Interval Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/lsmintervalprocessor)
+    # aggregates metrics in a db-backed over a defined interval and periodically
+    # forwards the latest values to the next component in the pipeline.
+    limits:
+      cpu: 1500m
+      memory: 1500Mi
+    requests:
+      cpu: 250m
+      memory: 1500Mi
+  presets:
+    kubernetesAttributes:
+      enabled: true
+    kubernetesEvents:
+      enabled: true
+    clusterMetrics:
+      enabled: true
+
+  extraEnvs:
+    - name: ELASTIC_AGENT_OTEL
+      value: "true"
+    - name: ELASTIC_OTLP_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: elastic-secret-otel
+          key: elastic_otlp_endpoint
+    - name: ELASTIC_OTLP_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: elastic-secret-otel
+          key: elastic_otlp_token
+    - name: GOMAXPROCS
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.cpu
+    - name: GOMEMLIMIT
+      value: "1025MiB"
+
+  alternateConfig:
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    connectors:
+      spanmetrics: {}
+      # [Signal To Metrics Connector](https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/signaltometricsconnector)
+      signaltometrics: # Produces metrics from all signal types (traces, logs, or metrics).
+        logs:
+          - name: service_summary
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: metricset.name
+                default_value: service_summary
+            sum:
+              value: "1"
+        datapoints:
+          - name: service_summary
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: metricset.name
+                default_value: service_summary
+            sum:
+              value: "1"
+        spans:
+          - name: service_summary
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: metricset.name
+                default_value: service_summary
+            sum:
+              value: Int(AdjustedCount())
+          - name: transaction.duration.histogram
+            description: APM service transaction aggregated metrics as histogram
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: transaction.root
+              - key: transaction.type
+              - key: metricset.name
+                default_value: service_transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [_doc_count]
+            unit: us
+            exponential_histogram:
+              value: Microseconds(end_time - start_time)
+              max_size: 2
+          - name: transaction.duration.summary
+            description: APM service transaction aggregated metrics as summary
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: transaction.root
+              - key: transaction.type
+              - key: metricset.name
+                default_value: service_transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [aggregate_metric_double]
+            unit: us
+            histogram:
+              buckets: [1]
+              value: Microseconds(end_time - start_time)
+          - name: transaction.duration.histogram
+            description: APM transaction aggregated metrics as histogram
+            ephemeral_resource_attribute: true
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+              - key: container.id
+              - key: k8s.pod.name
+              - key: service.version
+              - key: service.instance.id # service.node.name
+              - key: process.runtime.name # service.runtime.name
+              - key: process.runtime.version # service.runtime.version
+              - key: telemetry.sdk.version # service.language.version??
+              - key: host.name
+              - key: os.type # host.os.platform
+              - key: faas.instance
+              - key: faas.name
+              - key: faas.version
+              - key: cloud.provider
+              - key: cloud.region
+              - key: cloud.availability_zone
+              - key: cloud.platform # cloud.servicename
+              - key: cloud.account.id
+            attributes:
+              - key: transaction.root
+              - key: transaction.name
+              - key: transaction.type
+              - key: transaction.result
+              - key: event.outcome
+              - key: metricset.name
+                default_value: transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [_doc_count]
+            unit: us
+            exponential_histogram:
+              value: Microseconds(end_time - start_time)
+              max_size: 2
+          - name: transaction.duration.summary
+            description: APM transaction aggregated metrics as summary
+            ephemeral_resource_attribute: true
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+              - key: container.id
+              - key: k8s.pod.name
+              - key: service.version
+              - key: service.instance.id # service.node.name
+              - key: process.runtime.name # service.runtime.name
+              - key: process.runtime.version # service.runtime.version
+              - key: telemetry.sdk.version # service.language.version??
+              - key: host.name
+              - key: os.type # host.os.platform
+              - key: faas.instance
+              - key: faas.name
+              - key: faas.version
+              - key: cloud.provider
+              - key: cloud.region
+              - key: cloud.availability_zone
+              - key: cloud.platform # cloud.servicename
+              - key: cloud.account.id
+            attributes:
+              - key: transaction.root
+              - key: transaction.name
+              - key: transaction.type
+              - key: transaction.result
+              - key: event.outcome
+              - key: metricset.name
+                default_value: transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [aggregate_metric_double]
+            unit: us
+            histogram:
+              buckets: [1]
+              value: Microseconds(end_time - start_time)
+          - name: span.destination.service.response_time.sum.us
+            description: APM span destination metrics
+            ephemeral_resource_attribute: true
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: span.name
+              - key: event.outcome
+              - key: service.target.type
+              - key: service.target.name
+              - key: span.destination.service.resource
+              - key: metricset.name
+                default_value: service_destination
+            unit: us
+            sum:
+              value: Double(Microseconds(end_time - start_time))
+          - name: span.destination.service.response_time.count
+            description: APM span destination metrics
+            ephemeral_resource_attribute: true
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: span.name
+              - key: event.outcome
+              - key: service.target.type
+              - key: service.target.name
+              - key: span.destination.service.resource
+              - key: metricset.name
+                default_value: service_destination
+            sum:
+              value: Int(AdjustedCount())
+          # event.success_count is populated using 2 metric definition with different conditions
+          # and value for the histogram bucket based on event outcome. Both metric definition
+          # are created using same name and attribute and will result in a single histogram.
+          # We use mapping hint of aggregate_metric_double, so, only the sum and the count
+          # values are required and the actual histogram bucket is ignored.
+          - name: event.success_count
+            description: Success count as a metric for service transaction
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: transaction.root
+              - key: transaction.type
+              - key: metricset.name
+                default_value: service_transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [aggregate_metric_double]
+            conditions:
+              - attributes["event.outcome"] != nil and attributes["event.outcome"] == "success"
+            unit: us
+            histogram:
+              buckets: [1]
+              count: Int(AdjustedCount())
+              value: Int(AdjustedCount())
+          - name: event.success_count
+            description: Success count as a metric for service transaction
+            include_resource_attributes:
+              - key: service.name
+              - key: deployment.environment # service.environment
+              - key: telemetry.sdk.language # service.language.name
+              - key: agent.name # set via elastictraceprocessor
+            attributes:
+              - key: transaction.root
+              - key: transaction.type
+              - key: metricset.name
+                default_value: service_transaction
+              - key: elasticsearch.mapping.hints
+                default_value: [aggregate_metric_double]
+            conditions:
+              - attributes["event.outcome"] != nil and attributes["event.outcome"] != "success"
+            unit: us
+            histogram:
+              buckets: [0]
+              count: Int(AdjustedCount())
+              value: Double(0)
+    exporters:
+      debug: {}
+      otlphttp/elastic:
+        endpoint: "${env:ELASTIC_OTLP_ENDPOINT}"
+        headers:
+          Authorization: "ApiKey ${env:ELASTIC_OTLP_TOKEN}"
+    processors:
+      batch: {}
+      batch/metrics:
+        # explicitly set send_batch_max_size to 0, as splitting metrics requests may cause version_conflict_engine_exception in TSDB
+        send_batch_max_size: 0
+        timeout: 1s
+      batch/aggs:
+        send_batch_size: 16384 # 2x the default
+        timeout: 10s
+      resource:
+        attributes:
+          - key: deployment.environment
+            value: "opentelemetry-demo"
+            action: upsert
+      # Transform processor to remove services high cardinality on span names
+      transform/services:
+        error_mode: ignore
+        trace_statements:
+          - context: span
+            conditions:
+              - IsMatch(name, "^[A-Z]+\\s+.+")
+            statements:
+              - merge_maps(attributes, ExtractPatterns(name, "^(?P<method>\\S+)"), "upsert")
+              - set(name, attributes["method"])
+      # [Elastic Trace Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor)
+      elastictrace: {} # The processor enriches traces with elastic specific requirements.
+      # [LSM Interval Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/lsmintervalprocessor)
+      lsminterval:
+        intervals:
+          - duration: 1m
+            statements:
+              - set(resource.attributes["metricset.interval"], "1m")
+              - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "1m"], "."))
+              - set(attributes["processor.event"], "metric")
+          - duration: 10m
+            statements:
+              - set(resource.attributes["metricset.interval"], "10m")
+              - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "10m"], "."))
+              - set(attributes["processor.event"], "metric")
+          - duration: 60m
+            statements:
+              - set(resource.attributes["metricset.interval"], "60m")
+              - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "60m"], "."))
+              - set(attributes["processor.event"], "metric")
+      # [Resource Detection Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor)
+      resourcedetection/eks:
+        detectors: [env, eks] # Detects resources from environment variables and EKS (Elastic Kubernetes Service).
+        timeout: 15s
+        override: true
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+      resourcedetection/gcp:
+        detectors: [env, gcp] # Detects resources from environment variables and GCP (Google Cloud Platform).
+        timeout: 2s
+        override: true
+      resourcedetection/aks:
+        detectors: [env, aks] # Detects resources from environment variables and AKS (Azure Kubernetes Service).
+        timeout: 2s
+        override: true
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+      # [Resource Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)
+      resource/k8s: # Resource attributes tailored for services within Kubernetes.
+        attributes:
+          - key: service.name # Set the service.name resource attribute based on the well-known app.kubernetes.io/name label
+            from_attribute: app.label.name
+            action: insert
+          - key: service.name # Set the service.name resource attribute based on the k8s.container.name attribute
+            from_attribute: k8s.container.name
+            action: insert
+          - key: app.label.name # Delete app.label.name attribute previously used for service.name
+            action: delete
+          - key: service.version # Set the service.version resource attribute based on the well-known app.kubernetes.io/version label
+            from_attribute: app.label.version
+            action: insert
+          - key: app.label.version # Delete app.label.version attribute previously used for service.version
+            action: delete
+      resource/hostname:
+        attributes:
+          - key: host.name
+            from_attribute: k8s.node.name
+            action: upsert
+      # [K8s Attributes Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor)
+      k8sattributes:
+        passthrough: false # Annotates resources with the pod IP and does not try to extract any other metadata.
+        pod_association:
+          # Below association takes a look at the k8s.pod.ip and k8s.pod.uid resource attributes or connection's context, and tries to match it with the pod having the same attribute.
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: connection
+        extract:
+          metadata:
+            - "k8s.namespace.name"
+            - "k8s.deployment.name"
+            - "k8s.replicaset.name"
+            - "k8s.statefulset.name"
+            - "k8s.daemonset.name"
+            - "k8s.cronjob.name"
+            - "k8s.job.name"
+            - "k8s.node.name"
+            - "k8s.pod.name"
+            - "k8s.pod.ip"
+            - "k8s.pod.uid"
+            - "k8s.pod.start_time"
+          labels:
+            - tag_name: app.label.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: app.label.version
+              key: app.kubernetes.io/version
+              from: pod
+    receivers:
+     # [K8s Objects Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver)
+      k8sobjects:
+        objects:
+          - name: events
+            mode: "watch"
+            group: "events.k8s.io"
+            exclude_watch_type:
+              - "DELETED"
+      # [K8s Cluster Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver)
+      k8s_cluster:
+        auth_type: serviceAccount # Determines how to authenticate to the K8s API server. This can be one of none (for no auth), serviceAccount (to use the standard service account token provided to the agent pod), or kubeConfig to use credentials from ~/.kube/config.
+        node_conditions_to_report:
+          - Ready
+          - MemoryPressure
+        allocatable_types_to_report:
+          - cpu
+          - memory
+        metrics:
+          k8s.pod.status_reason:
+            enabled: true
+        resource_attributes:
+          k8s.kubelet.version:
+            enabled: true
+          os.description:
+            enabled: true
+          os.type:
+            enabled: true
+          k8s.container.status.last_terminated_reason:
+            enabled: true
+      httpcheck/frontendproxy:
+        targets:
+        - endpoint: http://example-frontendproxy:8080
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            cors:
+              allowed_origins:
+              - http://*
+              - https://*
+            endpoint: ${env:MY_POD_IP}:4318
+    service:
+      extensions:
+        - health_check
+      pipelines:
+        metrics/k8s:
+          exporters:
+          - debug
+          - otlphttp/elastic
+          processors:
+          - k8sattributes
+          - resourcedetection/eks
+          - resourcedetection/gcp
+          - resourcedetection/aks
+          - resource/k8s
+          - resource/hostname
+          receivers:
+          - k8s_cluster
+        logs/k8s:
+          receivers:
+          - k8sobjects
+          processors:
+          - resourcedetection/eks
+          - resourcedetection/gcp
+          - resourcedetection/aks
+          - resource/hostname
+          exporters:
+          - debug
+          - otlphttp/elastic
+        logs:
+          exporters:
+            - debug
+            - otlphttp/elastic
+            - signaltometrics
+          processors:
+            - batch
+            - resource
+          receivers:
+            - otlp
+        metrics:
+          exporters:
+            - otlphttp/elastic
+            - signaltometrics
+            - debug
+          processors:
+            - batch/metrics
+            - resource
+          receivers:
+            - httpcheck/frontendproxy
+            - otlp
+            - spanmetrics
+        traces:
+          exporters:
+            - otlphttp/elastic
+            - debug
+            - spanmetrics
+            - signaltometrics
+          processors:
+            - transform/services
+            - batch
+            - elastictrace
+            - resource
+          receivers:
+            - otlp
+        metrics/aggregated-otel-metrics:
+          receivers:
+            - signaltometrics
+          processors:
+            - batch/aggs
+            - lsminterval
+          exporters:
+            - debug
+            - otlphttp/elastic
+      telemetry:
+        metrics:
+          address: ${env:MY_POD_IP}:8888
+
+
+opensearch:
+  enabled: false
+
+grafana:
+  enabled: false
+
+jaeger:
+  enabled: false
+
+prometheus:
+  enabled: false

--- a/src/otel-collector/otelcol-elastic-otlp-config.yaml
+++ b/src/otel-collector/otelcol-elastic-otlp-config.yaml
@@ -159,6 +159,11 @@ processors:
           - set(resource.attributes["metricset.interval"], "10m")
           - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "10m"], "."))
           - set(attributes["processor.event"], "metric")
+      - duration: 60m
+        statements:
+          - set(resource.attributes["metricset.interval"], "60m")
+          - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "60m"], "."))
+          - set(attributes["processor.event"], "metric")
 
 connectors:
   spanmetrics:

--- a/src/otel-collector/otelcol-elastic-otlp-config.yaml
+++ b/src/otel-collector/otelcol-elastic-otlp-config.yaml
@@ -415,18 +415,6 @@ service:
         - batch
       receivers:
         - otlp
-    # metrics/infra/ecs:
-    #   exporters:
-    #     - elasticsearch/ecs
-    #     - debug
-    #   processors:
-    #     - batch
-    #     - elasticinframetrics
-    #     - resourcedetection/system
-    #     - attributes/dataset
-    #     - resource/process
-    #   receivers:
-    #     - hostmetrics
     metrics/infra/otel:
       exporters:
         - otlphttp/elastic

--- a/src/otel-collector/otelcol-elastic-otlp-config.yaml
+++ b/src/otel-collector/otelcol-elastic-otlp-config.yaml
@@ -1,0 +1,465 @@
+exporters:
+  debug:
+  otlphttp/elastic:
+    endpoint: "YOUR_OTEL_EXPORTER_OTLP_ENDPOINT"
+    headers:
+      Authorization: "ApiKey YOUR_OTEL_EXPORTER_OTLP_TOKEN"
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_GRPC}
+      http:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_HTTP}
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+  httpcheck/frontendproxy:
+    targets:
+      - endpoint: http://frontendproxy:${env:ENVOY_PORT}
+  hostmetrics:
+    collection_interval: 10s
+    root_path: /hostfs
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+          system.cpu.logical.count:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+        metrics:
+          process.threads:
+            enabled: true
+          process.open_file_descriptors:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.disk.operations:
+            enabled: true
+      network:
+      processes:
+      load:
+      disk:
+      filesystem:
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/k3s/containerd/*
+            - /var/lib/docker/*
+            - /var/lib/kubelet/*
+            - /snap/*
+          match_type: regexp
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+          match_type: strict
+
+processors:
+  batch:
+  elasticinframetrics:
+    add_system_metrics: true
+    add_k8s_metrics: false
+    drop_original: true
+  resource/process:
+    attributes:
+      - key: process.executable.name
+        action: delete
+      - key: process.executable.path
+        action: delete
+  attributes/dataset:
+    actions:
+      - key: event.dataset
+        from_attribute: data_stream.dataset
+        action: upsert
+  resourcedetection/system:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.id:
+          enabled: false
+        host.arch:
+          enabled: true
+        host.ip:
+          enabled: true
+        host.mac:
+          enabled: true
+        host.cpu.vendor.id:
+          enabled: true
+        host.cpu.family:
+          enabled: true
+        host.cpu.model.id:
+          enabled: true
+        host.cpu.model.name:
+          enabled: true
+        host.cpu.stepping:
+          enabled: true
+        host.cpu.cache.l2.size:
+          enabled: true
+        os.description:
+          enabled: true
+        os.type:
+          enabled: true
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # could be removed when https://github.com/vercel/next.js/pull/64852 is fixed upstream
+          - replace_pattern(name, "\\?.*", "")
+          - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
+  # [Elastic Trace Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor)
+  elastictrace: {} # The processor enriches traces with elastic specific requirements.
+  # [LSM Interval Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/lsmintervalprocessor)
+  lsminterval:
+    intervals:
+      - duration: 1m
+        statements:
+          - set(resource.attributes["metricset.interval"], "1m")
+          - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "1m"], "."))
+          - set(attributes["processor.event"], "metric")
+      - duration: 10m
+        statements:
+          - set(resource.attributes["metricset.interval"], "10m")
+          - set(attributes["data_stream.dataset"], Concat([attributes["metricset.name"], "10m"], "."))
+          - set(attributes["processor.event"], "metric")
+
+connectors:
+  spanmetrics:
+  # [Signal To Metrics Connector](https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/signaltometricsconnector)
+  signaltometrics: # Produces metrics from all signal types (traces, logs, or metrics).
+    logs:
+      - name: service_summary
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: metricset.name
+            default_value: service_summary
+        sum:
+          value: "1"
+    datapoints:
+      - name: service_summary
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: metricset.name
+            default_value: service_summary
+        sum:
+          value: "1"
+    spans:
+      - name: service_summary
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: metricset.name
+            default_value: service_summary
+        sum:
+          value: Int(AdjustedCount())
+      - name: transaction.duration.histogram
+        description: APM service transaction aggregated metrics as histogram
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: transaction.root
+          - key: transaction.type
+          - key: metricset.name
+            default_value: service_transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [_doc_count]
+        unit: us
+        exponential_histogram:
+          value: Microseconds(end_time - start_time)
+          max_size: 2
+      - name: transaction.duration.summary
+        description: APM service transaction aggregated metrics as summary
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: transaction.root
+          - key: transaction.type
+          - key: metricset.name
+            default_value: service_transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [aggregate_metric_double]
+        unit: us
+        histogram:
+          buckets: [1]
+          value: Microseconds(end_time - start_time)
+      - name: transaction.duration.histogram
+        description: APM transaction aggregated metrics as histogram
+        ephemeral_resource_attribute: true
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+          - key: container.id
+          - key: k8s.pod.name
+          - key: service.version
+          - key: service.instance.id # service.node.name
+          - key: process.runtime.name # service.runtime.name
+          - key: process.runtime.version # service.runtime.version
+          - key: telemetry.sdk.version # service.language.version??
+          - key: host.name
+          - key: os.type # host.os.platform
+          - key: faas.instance
+          - key: faas.name
+          - key: faas.version
+          - key: cloud.provider
+          - key: cloud.region
+          - key: cloud.availability_zone
+          - key: cloud.platform # cloud.servicename
+          - key: cloud.account.id
+        attributes:
+          - key: transaction.root
+          - key: transaction.name
+          - key: transaction.type
+          - key: transaction.result
+          - key: event.outcome
+          - key: metricset.name
+            default_value: transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [_doc_count]
+        unit: us
+        exponential_histogram:
+          value: Microseconds(end_time - start_time)
+          max_size: 2
+      - name: transaction.duration.summary
+        description: APM transaction aggregated metrics as summary
+        ephemeral_resource_attribute: true
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+          - key: container.id
+          - key: k8s.pod.name
+          - key: service.version
+          - key: service.instance.id # service.node.name
+          - key: process.runtime.name # service.runtime.name
+          - key: process.runtime.version # service.runtime.version
+          - key: telemetry.sdk.version # service.language.version??
+          - key: host.name
+          - key: os.type # host.os.platform
+          - key: faas.instance
+          - key: faas.name
+          - key: faas.version
+          - key: cloud.provider
+          - key: cloud.region
+          - key: cloud.availability_zone
+          - key: cloud.platform # cloud.servicename
+          - key: cloud.account.id
+        attributes:
+          - key: transaction.root
+          - key: transaction.name
+          - key: transaction.type
+          - key: transaction.result
+          - key: event.outcome
+          - key: metricset.name
+            default_value: transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [aggregate_metric_double]
+        unit: us
+        histogram:
+          buckets: [1]
+          value: Microseconds(end_time - start_time)
+      - name: span.destination.service.response_time.sum.us
+        description: APM span destination metrics
+        ephemeral_resource_attribute: true
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: span.name
+          - key: event.outcome
+          - key: service.target.type
+          - key: service.target.name
+          - key: span.destination.service.resource
+          - key: metricset.name
+            default_value: service_destination
+        unit: us
+        sum:
+          value: Double(Microseconds(end_time - start_time))
+      - name: span.destination.service.response_time.count
+        description: APM span destination metrics
+        ephemeral_resource_attribute: true
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: span.name
+          - key: event.outcome
+          - key: service.target.type
+          - key: service.target.name
+          - key: span.destination.service.resource
+          - key: metricset.name
+            default_value: service_destination
+        sum:
+          value: Int(AdjustedCount())
+      # event.success_count is populated using 2 metric definition with different conditions
+      # and value for the histogram bucket based on event outcome. Both metric definition
+      # are created using same name and attribute and will result in a single histogram.
+      # We use mapping hint of aggregate_metric_double, so, only the sum and the count
+      # values are required and the actual histogram bucket is ignored.
+      - name: event.success_count
+        description: Success count as a metric for service transaction
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: transaction.root
+          - key: transaction.type
+          - key: metricset.name
+            default_value: service_transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [aggregate_metric_double]
+        conditions:
+          - attributes["event.outcome"] != nil and attributes["event.outcome"] == "success"
+        unit: us
+        histogram:
+          buckets: [1]
+          count: Int(AdjustedCount())
+          value: Int(AdjustedCount())
+      - name: event.success_count
+        description: Success count as a metric for service transaction
+        include_resource_attributes:
+          - key: service.name
+          - key: deployment.environment # service.environment
+          - key: telemetry.sdk.language # service.language.name
+          - key: agent.name # set via elastictraceprocessor
+        attributes:
+          - key: transaction.root
+          - key: transaction.type
+          - key: metricset.name
+            default_value: service_transaction
+          - key: elasticsearch.mapping.hints
+            default_value: [aggregate_metric_double]
+        conditions:
+          - attributes["event.outcome"] != nil and attributes["event.outcome"] != "success"
+        unit: us
+        histogram:
+          buckets: [0]
+          count: Int(AdjustedCount())
+          value: Double(0)
+
+service:
+  pipelines:
+    logs:
+      exporters:
+        - debug
+        - otlphttp/elastic
+        - signaltometrics
+      processors:
+        - batch
+      receivers:
+        - otlp
+    # metrics/infra/ecs:
+    #   exporters:
+    #     - elasticsearch/ecs
+    #     - debug
+    #   processors:
+    #     - batch
+    #     - elasticinframetrics
+    #     - resourcedetection/system
+    #     - attributes/dataset
+    #     - resource/process
+    #   receivers:
+    #     - hostmetrics
+    metrics/infra/otel:
+      exporters:
+        - otlphttp/elastic
+        - debug
+      processors:
+        - batch
+        - resourcedetection/system
+      receivers:
+        - hostmetrics
+    metrics:
+      exporters:
+        - otlphttp/elastic
+        - signaltometrics
+        - debug
+      processors:
+        - batch
+      receivers:
+        - httpcheck/frontendproxy
+        - otlp
+        - spanmetrics
+    traces:
+      exporters:
+        - otlphttp/elastic
+        - debug
+        - spanmetrics
+        - signaltometrics
+      processors:
+        - transform
+        - batch
+        - elastictrace
+      receivers:
+        - otlp
+    metrics/aggregated-otel-metrics:
+      receivers:
+        - signaltometrics
+      processors:
+        - batch
+        - lsminterval
+      exporters:
+        - debug
+        - otlphttp/elastic


### PR DESCRIPTION
# Changes

This PR introduces support for the Managed Ingest Endpoint using otlphttp exporters. It serves as a temporary solution until a more streamlined approach is implemented upstream (ref: [opentelemetry-demo#2052](https://github.com/open-telemetry/opentelemetry-demo/issues/2052)).

The Kubernetes and Docker Compose configurations are adapted from existing setups that use the Elasticsearch exporter.

- relates to https://github.com/elastic/opentelemetry-dev/issues/621


