### PR TITLE
Update checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@49cf4f8da82db70e691bb8284053add5028fa244  # v1.3.2
         with:
           level: info
           fail_level: any


### PR DESCRIPTION
Pinning action to a full length commit SHA [see](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
