### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -46,7 +46,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Follow the [EDOT Quick Start Guide](https://elastic.github.io/opentelemetry/quickstart/) for Kubernetes and your specific Elastic deployment to install the EDOT OpenTelemetry collector.
 - Deploy the Elastic OpenTelemetry Demo using the following command.
   ```
-  helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yaml
+  helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yml
   ```
 
 #### Kubernetes architecture diagram


### PR DESCRIPTION
Fixed typo in instructions

# Changes

Fixed a typo, because the instructions refer a non-existing file, hence copy-and-paste is impossible.
