### PR TITLE
Register the EDOT (not vanilla SDK)

### DIFF
--- a/src/cart/src/cart.csproj
+++ b/src/cart/src/cart.csproj
@@ -17,16 +17,9 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.67.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.11.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.11.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Resources.Container" Version="1.11.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Resources.Host" Version="1.11.0-beta.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
     <PackageReference Include="OpenFeature.Contrib.Providers.Flagd" Version="0.3.0" />
     <PackageReference Include="OpenFeature.Contrib.Hooks.Otel" Version="0.2.0" />


### PR DESCRIPTION
The current cart code (`AddOpenTelemetry`) registers using the vanilla SDK, not EDOT. In early alphas, we intercepted this and registered EDOT, but we decided to make it an explicit choice.

This PR updates the registration to use the EDOT API, reducing the boilerplate code required. EDOT also brings in a set of transitive dependencies, so I've removed the explicit package references for those from the project file.