### PR TITLE
rollback elastic-agent docker override version to 8.17.4

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -15,6 +15,6 @@ KAFKA_SERVICE_DOCKERFILE=./src/kafka/Dockerfile.elastic
 # *********************
 # Elastic Collector
 # *********************
-COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/elastic-agent/elastic-agent:9.0.0
+COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/elastic-agent/elastic-agent:8.17.4
 OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-config.yaml
 ELASTIC_AGENT_OTEL=true


### PR DESCRIPTION
# Changes

A few EDOT collector components were removed with 9.0.0:

```
Starting in otel mode
failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

error decoding 'processors': unknown type: "lsminterval" for id: "lsminterval" (valid values: [resource transform resourcedetection memory_limiter elastictrace batch attributes filter geoip k8sattributes elasticinframetrics])
error decoding 'connectors': unknown type: "signaltometrics" for id: "signaltometrics" (valid values: [routing spanmetrics elasticapm])
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
