### PR TITLE
Add wrapper bash script to deploy the demo

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -15,9 +15,9 @@ KAFKA_SERVICE_DOCKERFILE=./src/kafka/Dockerfile.elastic
 # *********************
 # Elastic Collector
 # *********************
-COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/elastic-agent/elastic-agent:9.1.0
-OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-config.yaml
 ELASTIC_AGENT_OTEL=true
-ELASTICSEARCH_ENDPOINT="YOUR_ELASTICSEARCH_ENDPOINT"
-ELASTICSEARCH_API_KEY="YOUR_ELASTICSEARCH_API_KEY"
+COLLECTOR_CONTRIB_IMAGE="docker.elastic.co/elastic-agent/elastic-agent:9.1.3"
+OTEL_COLLECTOR_CONFIG="./src/otel-collector/otelcol-elastic-config.yaml"
+ELASTICSEARCH_ENDPOINT="YOUR_ENDPOINT"
+ELASTICSEARCH_API_KEY="YOUR_API_KEY"
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,30 +10,54 @@ The following guide describes how to setup the OpenTelemetry demo with Elastic O
 
 Additionally, the OpenTelemetry Contrib collector has also been changed to the [Elastic OpenTelemetry Collector distribution](https://github.com/elastic/elastic-agent/blob/main/internal/pkg/otel/README.md). This ensures a more integrated and optimized experience with Elastic Observability.
 
-## Docker compose
+## Docker
 
-### Elasticsearch exporter (default)
+### Prerequisites:
+
+- Install [Docker](https://docs.docker.com/get-started/get-docker/)
+- Install [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Automated script
+
+#### Elasticsearch exporter (default)
+
 1. Start a free trial on [Elastic Cloud](https://cloud.elastic.co/) and copy the `Elasticsearch endpoint` and the `API Key` from the `Help -> Connection details` drop down instructions in your Kibana. These variables will be used by the [elasticsearch exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter#elasticsearch-exporter) to authenticate and transmit data to your Elasticsearch instance.
-2. Open the file `.env.override` in an editor and replace all occurrences the following two placeholders:
-   - `YOUR_ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
-   - `YOUR_ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
+2. Run `./demo.sh cloud-hosted docker`.
+
+#### Managed Ingest Endpoint
+1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Add data, Application and then OpenTelemetry.
+2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL.
+3. Click "Create an API Key" to create one.
+4. Run `./demo.sh serverless docker`
+
+
+### Manual Configuration
+<details> 
+
+#### Elasticsearch exporter
+1. Start a free trial on [Elastic Cloud](https://cloud.elastic.co/) and copy the `Elasticsearch endpoint` and the `API Key` from the `Help -> Connection details` drop down instructions in your Kibana. These variables will be used by the [elasticsearch exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter#elasticsearch-exporter) to authenticate and transmit data to your Elasticsearch instance.
+2. Open the file `.env.override` in an editor and fill in the following two variables:
+   - `ELASTICSEARCH_ENDPOINT`: your Elasticsearch endpoint (*with* `https://` prefix example: `https://1234567.us-west2.gcp.elastic-cloud.com:443`).
+   - `ELASTICSEARCH_API_KEY`: your Elasticsearch API Key
+3. Add `src/otel-collector/otelcol-elastic-config.yaml` as `OTEL_COLLECTOR_CONFIG`
 3. Start the demo with the following command from the repository's root directory:
    ```
    make start
    ```
 
-### Managed Ingest Endpoint
+#### Managed Ingest Endpoint
 1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Add data, Application and then OpenTelemetry.
 2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL.
 3. Click "Create an API Key" to create one.
-4. Open the file `.env.override` in an editor and replace all occurrences the following two placeholders:
-   - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT_URL.
-   - `YOUR_OTEL_EXPORTER_OTLP_TOKEN`: your Elastic OTLP endpoint token. This is what comes after `ApiKey=`.
+4. Open the file `.env.override` in an editor and fill in the following two variables:
+   - `ELASTICSEARCH_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT_URL.
+   - `ELASTICSEARCH_API_KEY`: your Elastic OTLP endpoint token. This is what comes after `ApiKey=`.
 5. Add `src/otel-collector/otelcol-elastic-otlp-config.yaml` as `OTEL_COLLECTOR_CONFIG`
 6. Start the demo with the following command from the repository's root directory:
    ```
    make start
    ```
+</details>
 
 ## Kubernetes
 ### Prerequisites:
@@ -41,13 +65,22 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Set up [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 - Set up [Helm](https://helm.sh/).
 
-### Installation
+### Automated Script
+
+- **Elasticsearch exporter:** Run `./demo.sh cloud-hosted k8s`
+- **Managed Ingest Endpoint:** Run `./demo.sh serverless k8s`
+
+### Manual Configuration
+
+<details>
 
 - Follow the [EDOT Quick Start Guide](https://elastic.github.io/opentelemetry/quickstart/) for Kubernetes and your specific Elastic deployment to install the EDOT OpenTelemetry collector.
 - Deploy the Elastic OpenTelemetry Demo using the following command.
   ```
   helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yml
   ```
+
+</details>
 
 #### Enabling Browser Traffic Generation
 
@@ -88,7 +121,7 @@ In the installed configuration, browser-based load generation is disabled by def
 ## Testing with a custom component
 
 Suppose you want to see how your new processor is going to play out in this demo app. You can create a custom OpenTelemetry collector and test it within this demo app by following these steps:
-1. Follow the instructions in the [elastic-collector-componenets](https://github.com/elastic/opentelemetry-collector-components/blob/main/README.md) repo in order to build a Docker image
+1. Follow the instructions in the [elastic-collector-components](https://github.com/elastic/opentelemetry-collector-components/blob/main/README.md) repo in order to build a Docker image
    that contains your custom component
 2. Edit the [deployment.yaml](https://github.com/elastic/opentelemetry-demo/blob/main/kubernetes/elastic-helm/deployment.yaml) file:
    - change the `opentelemetry-collector` [image definitions](https://github.com/elastic/opentelemetry-demo/blob/27b4923ba9acd316d3726a29aad1f7e32299bc8c/kubernetes/elastic-helm/deployment.yaml#L36)
@@ -111,3 +144,8 @@ Suppose you want to see how your new processor is going to play out in this demo
    # deploy the demo through helm install
    helm install -f deployment.yaml my-otel-demo open-telemetry/opentelemetry-demo
    ```
+
+## Clean-up 
+
+- **Docker**. Run `./demo.sh destroy docker`
+- **Kubernetes**. Run `./demo.sh destroy k8s`

--- a/.github/README.md
+++ b/.github/README.md
@@ -71,7 +71,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - **Elasticsearch exporter:** Run `./demo.sh cloud-hosted k8s`
 - **Managed Ingest Endpoint:** Run `./demo.sh serverless k8s`
 
-### Manual Configuration
+### Manual Installation
 
 <details>
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -66,7 +66,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Set up [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 - Set up [Helm](https://helm.sh/).
 
-### Automated Script
+### Automated Installation
 
 - **Elasticsearch exporter:** Run `./demo.sh cloud-hosted k8s`
 - **Managed Ingest Endpoint:** Run `./demo.sh serverless k8s`

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,8 +23,8 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
    ```
 
 ### Managed Ingest Endpoint
-1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Application and then OpenTelemetry.
-2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL and replace `.apm` with `.ingest`.
+1. Sign up for a free trial on [Elastic Cloud](https://cloud.elastic.co/) and start an Elastic Cloud Serverless Observability type project. Select Add data, Application and then OpenTelemetry.
+2. Copy the OTEL_EXPORTER_OTLP_ENDPOINT URL.
 3. Click "Create an API Key" to create one.
 4. Open the file `.env.override` in an editor and replace all occurrences the following two placeholders:
    - `YOUR_OTEL_EXPORTER_OTLP_ENDPOINT`: your OTEL_EXPORTER_OTLP_ENDPOINT_URL.

--- a/.github/README.md
+++ b/.github/README.md
@@ -17,7 +17,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Install [Docker](https://docs.docker.com/get-started/get-docker/)
 - Install [Docker Compose](https://docs.docker.com/compose/install/)
 
-### Automated script
+### Automated Installation
 
 #### Elasticsearch exporter (default)
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -31,7 +31,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 4. Run `./demo.sh serverless docker`
 
 
-### Manual Configuration
+### Manual Installation
 <details> 
 
 #### Elasticsearch exporter

--- a/demo.sh
+++ b/demo.sh
@@ -14,7 +14,7 @@ DEMO_CHART="open-telemetry/opentelemetry-demo"
 
 KUBE_STACK_RELEASE="opentelemetry-kube-stack"
 KUBE_STACK_CHART="open-telemetry/opentelemetry-kube-stack"
-KUBE_STACK_VERSION='0.3.3'
+KUBE_STACK_VERSION='0.9.1'
 KUBE_STACK_VALUES_URL_CLOUD='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/values.yaml'
 KUBE_STACK_VALUES_URL_SERVERLESS='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml'
 SECRET_NAME='elastic-secret-otel'

--- a/demo.sh
+++ b/demo.sh
@@ -1,36 +1,58 @@
 #!/bin/sh
 
-set -eux
+set -eu
 
+# Constants
+ELASTIC_STACK_VERSION="9.1.3"
 ENV_OVERRIDE_FILE=".env.override"
+NAMESPACE="opentelemetry-operator-system"
+HELM_REPO_NAME="open-telemetry"
+HELM_REPO_URL='https://open-telemetry.github.io/opentelemetry-helm-charts'
 
-SCENARIO=""
+DEMO_RELEASE="my-otel-demo"
+DEMO_CHART="open-telemetry/opentelemetry-demo"
+
+KUBE_STACK_RELEASE="opentelemetry-kube-stack"
+KUBE_STACK_CHART="open-telemetry/opentelemetry-kube-stack"
+KUBE_STACK_VERSION='0.3.3'
+KUBE_STACK_VALUES_URL_CLOUD='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/values.yaml'
+KUBE_STACK_VALUES_URL_SERVERLESS='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml'
+SECRET_NAME='elastic-secret-otel'
+
+DOCKER_COLLECTOR_CONFIG_CLOUD='./src/otel-collector/otelcol-elastic-config.yaml'
+DOCKER_COLLECTOR_CONFIG_SERVERLESS='./src/otel-collector/otelcol-elastic-otlp-config.yaml'
+COLLECTOR_CONTRIB_IMAGE=docker.elastic.co/elastic-agent/elastic-agent:$ELASTIC_STACK_VERSION
+
+
+# Variables
+ELASTIC_DEPLOYMENT_TYPE=""
 PLATFORM=""
+DESTROY="false"
 ELASTICSEARCH_ENDPOINT=""
 ELASTICSEARCH_API_KEY=""
 
 usage() {
-    echo "Usage: $0 --scenario [cloud-hosted|serverless] --platform [docker|k8s]"
+    echo "Usage: $0 [cloud-hosted|serverless] [docker|k8s] | destroy [docker|k8s]"
     exit 1
 }
 
 parse_args() {
-  while [ $# -gt 0 ]; do
-    case "$1" in
-      --scenario)
-        SCENARIO="$2"
-        shift 2
-        ;;
-      --platform)
-        PLATFORM="$2"
-        shift 2
-        ;;
-      *)
-        echo "Unknown argument: $1"
-        usage
-        ;;
-    esac
-  done
+  if [ $# -eq 0 ]; then
+    usage
+  fi
+
+  if [ "$1" = "destroy" ]; then
+    DESTROY="true"
+    if [ $# -ge 2 ]; then
+      PLATFORM="$2"
+    fi
+    return
+  fi
+
+  ELASTIC_DEPLOYMENT_TYPE="$1"
+  if [ $# -ge 2 ]; then
+    PLATFORM="$2"
+  fi
 }
 
 update_env_var() {
@@ -43,28 +65,7 @@ update_env_var() {
   fi
 }
 
-parse_args "$@"
-
-if [ "$SCENARIO" != "cloud-hosted" ] && [ "$SCENARIO" != "serverless" ]; then
-  usage
-fi
-
-if [ "$PLATFORM" != "docker" ] && [ "$PLATFORM" != "k8s" ]; then
-  usage
-fi
-
-echo "Starting '$SCENARIO' scenario on '$PLATFORM'..."
-
-if [ "$PLATFORM" = "docker" ]; then
-  case "$SCENARIO" in
-    cloud-hosted)
-      OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-config.yaml
-      ;;
-    serverless)
-      OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-otlp-config.yaml
-      ;;
-  esac
-
+ensure_env_values() {
   if [ -z "$ELASTICSEARCH_ENDPOINT" ]; then
     printf "Enter your Elastic endpoint: "
     read ELASTICSEARCH_ENDPOINT
@@ -74,50 +75,141 @@ if [ "$PLATFORM" = "docker" ]; then
     printf "Enter your Elastic API key: "
     read ELASTICSEARCH_API_KEY
   fi
+}
+
+# Resolve OTEL Collector config path for Docker based on ELASTIC_DEPLOYMENT_TYPE
+set_docker_collector_config() {
+  case "$ELASTIC_DEPLOYMENT_TYPE" in
+    cloud-hosted)
+      OTEL_COLLECTOR_CONFIG=$DOCKER_COLLECTOR_CONFIG_CLOUD
+      ;;
+    serverless)
+      OTEL_COLLECTOR_CONFIG=$DOCKER_COLLECTOR_CONFIG_SERVERLESS
+      ;;
+  esac
+}
+
+start_docker() {
+  set_docker_collector_config
+  ensure_env_values
 
   update_env_var "ELASTICSEARCH_ENDPOINT" "$ELASTICSEARCH_ENDPOINT"
   update_env_var "ELASTICSEARCH_API_KEY" "$ELASTICSEARCH_API_KEY"
   update_env_var "OTEL_COLLECTOR_CONFIG" "$OTEL_COLLECTOR_CONFIG"
+  update_env_var "COLLECTOR_CONTRIB_IMAGE" "$COLLECTOR_CONTRIB_IMAGE"
 
   make start
-elif [ "$PLATFORM" = "k8s" ]; then
-  helm repo add open-telemetry 'https://open-telemetry.github.io/opentelemetry-helm-charts' --force-update
-  kubectl create namespace opentelemetry-operator-system
-  if [ -z "$ELASTICSEARCH_ENDPOINT" ]; then
-    printf "Enter your Elastic endpoint: "
-    read ELASTICSEARCH_ENDPOINT
-  fi
+}
 
-  if [ -z "$ELASTICSEARCH_API_KEY" ]; then
-    printf "Enter your Elastic API key: "
-    read ELASTICSEARCH_API_KEY
+ensure_k8s_prereqs() {
+  helm repo add "$HELM_REPO_NAME" "$HELM_REPO_URL" --force-update
+  if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    kubectl create namespace "$NAMESPACE"
   fi
-  case "$SCENARIO" in
+}
+
+apply_k8s_secret() {
+  ensure_env_values
+  case "$ELASTIC_DEPLOYMENT_TYPE" in
     cloud-hosted)
-      kubectl create secret generic elastic-secret-otel \
-      --namespace opentelemetry-operator-system \
-      --from-literal=elastic_endpoint="$ELASTICSEARCH_ENDPOINT" \
-      --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY"
-
-      helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
-      --namespace opentelemetry-operator-system \
-      --values 'https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.3/deploy/helm/edot-collector/kube-stack/values.yaml' \
-      --version '0.3.3'
+      kubectl create secret generic "$SECRET_NAME" \
+        --namespace "$NAMESPACE" \
+        --from-literal=elastic_endpoint="$ELASTICSEARCH_ENDPOINT" \
+        --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY" \
+        --dry-run=client -o yaml | kubectl apply -f -
       ;;
     serverless)
-      
-      kubectl create secret generic elastic-secret-otel \
-      --namespace opentelemetry-operator-system \
-      --from-literal=elastic_otlp_endpoint="$ELASTICSEARCH_ENDPOINT" \
-      --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY"
-
-      helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
-      --namespace opentelemetry-operator-system \
-      --values 'https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.3/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml' \
-      --version '0.3.3'
+      kubectl create secret generic "$SECRET_NAME" \
+        --namespace "$NAMESPACE" \
+        --from-literal=elastic_otlp_endpoint="$ELASTICSEARCH_ENDPOINT" \
+        --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY" \
+        --dry-run=client -o yaml | kubectl apply -f -
       ;;
   esac
-  helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yml
-fi
+}
 
-echo "Done! '$SCENARIO' started on '$PLATFORM'."
+install_kube_stack() {
+  case "$ELASTIC_DEPLOYMENT_TYPE" in
+    cloud-hosted)
+      VALUES_URL="$KUBE_STACK_VALUES_URL_CLOUD"
+      ;;
+    serverless)
+      VALUES_URL="$KUBE_STACK_VALUES_URL_SERVERLESS"
+      ;;
+  esac
+
+  helm upgrade --install "$KUBE_STACK_RELEASE" "$KUBE_STACK_CHART" \
+    --namespace "$NAMESPACE" \
+    --values "$VALUES_URL" \
+    --version "$KUBE_STACK_VERSION"
+}
+
+install_demo_chart() {
+  helm upgrade --install "$DEMO_RELEASE" "$DEMO_CHART" -f kubernetes/elastic-helm/demo.yml
+}
+
+start_k8s() {
+  ensure_k8s_prereqs
+  apply_k8s_secret
+  install_kube_stack
+  install_demo_chart
+}
+
+destroy_docker() {
+  make stop
+}
+
+destroy_k8s() {
+  helm uninstall "$DEMO_RELEASE" --ignore-not-found
+  helm uninstall "$KUBE_STACK_RELEASE" -n "$NAMESPACE" --ignore-not-found
+  kubectl delete secret "$SECRET_NAME" -n "$NAMESPACE" --ignore-not-found
+  kubectl delete namespace "$NAMESPACE" --ignore-not-found --wait=false --timeout=60s
+}
+
+main() {
+  parse_args "$@"
+
+  if [ "$DESTROY" = "true" ]; then
+    if [ -z "$PLATFORM" ]; then
+      echo "Destroying Docker and Kubernetes resources..."
+      destroy_docker
+      destroy_k8s
+      echo "Done! Destroyed Docker and Kubernetes resources."
+      return 0
+    fi
+
+    if [ "$PLATFORM" = "docker" ]; then
+      echo "Destroying Docker resources..."
+      destroy_docker
+      echo "Done! Destroyed Docker resources."
+      return 0
+    fi
+
+    if [ "$PLATFORM" = "k8s" ]; then
+      echo "Destroying Kubernetes resources..."
+      destroy_k8s
+      echo "Done! Destroyed Kubernetes resources."
+      return 0
+    fi
+
+    usage
+  fi
+
+  if [ "$ELASTIC_DEPLOYMENT_TYPE" != "cloud-hosted" ] && [ "$ELASTIC_DEPLOYMENT_TYPE" != "serverless" ]; then
+    usage
+  fi
+
+  if [ "$PLATFORM" != "docker" ] && [ "$PLATFORM" != "k8s" ]; then
+    usage
+  fi
+
+  echo "Starting '$ELASTIC_DEPLOYMENT_TYPE' on '$PLATFORM'..."
+  if [ "$PLATFORM" = "docker" ]; then
+    start_docker
+  else
+    start_k8s
+  fi
+  echo "Done! '$ELASTIC_DEPLOYMENT_TYPE' started on '$PLATFORM'."
+}
+
+main "$@"

--- a/demo.sh
+++ b/demo.sh
@@ -67,7 +67,11 @@ update_env_var() {
 
 ensure_env_values() {
   if [ -z "$elasticsearch_endpoint" ]; then
-    printf "Enter your Elastic endpoint: "
+    if [ $deployment_type = "serverless" ]; then
+      printf "Enter your Elastic OTLP endpoint: "
+    else
+      printf "Enter your Elastic endpoint: "
+    fi
     read elasticsearch_endpoint
   fi
 

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+set -eux
+
+ENV_OVERRIDE_FILE=".env.override"
+
+SCENARIO=""
+PLATFORM=""
+ELASTICSEARCH_ENDPOINT=""
+ELASTICSEARCH_API_KEY=""
+
+usage() {
+    echo "Usage: $0 --scenario [cloud-hosted|serverless] --platform [docker|k8s]"
+    exit 1
+}
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --scenario)
+        SCENARIO="$2"
+        shift 2
+        ;;
+      --platform)
+        PLATFORM="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        usage
+        ;;
+    esac
+  done
+}
+
+update_env_var() {
+  VAR="$1"
+  VAL="$2"
+  if grep -q "^$VAR=" "$ENV_OVERRIDE_FILE"; then
+    sed -i '' "s|^$VAR=.*|$VAR=\"$VAL\"|" "$ENV_OVERRIDE_FILE"
+  else
+    echo "$VAR=\"$VAL\"" >> "$ENV_OVERRIDE_FILE"
+  fi
+}
+
+parse_args "$@"
+
+if [ "$SCENARIO" != "cloud-hosted" ] && [ "$SCENARIO" != "serverless" ]; then
+  usage
+fi
+
+if [ "$PLATFORM" != "docker" ] && [ "$PLATFORM" != "k8s" ]; then
+  usage
+fi
+
+echo "Starting '$SCENARIO' scenario on '$PLATFORM'..."
+
+if [ "$PLATFORM" = "docker" ]; then
+  case "$SCENARIO" in
+    cloud-hosted)
+      OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-config.yaml
+      ;;
+    serverless)
+      OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-otlp-config.yaml
+      ;;
+  esac
+
+  if [ -z "$ELASTICSEARCH_ENDPOINT" ]; then
+    printf "Enter your Elastic endpoint: "
+    read ELASTICSEARCH_ENDPOINT
+  fi
+
+  if [ -z "$ELASTICSEARCH_API_KEY" ]; then
+    printf "Enter your Elastic API key: "
+    read ELASTICSEARCH_API_KEY
+  fi
+
+  update_env_var "ELASTICSEARCH_ENDPOINT" "$ELASTICSEARCH_ENDPOINT"
+  update_env_var "ELASTICSEARCH_API_KEY" "$ELASTICSEARCH_API_KEY"
+  update_env_var "OTEL_COLLECTOR_CONFIG" "$OTEL_COLLECTOR_CONFIG"
+
+  make start
+elif [ "$PLATFORM" = "k8s" ]; then
+  helm repo add open-telemetry 'https://open-telemetry.github.io/opentelemetry-helm-charts' --force-update
+  kubectl create namespace opentelemetry-operator-system
+  if [ -z "$ELASTICSEARCH_ENDPOINT" ]; then
+    printf "Enter your Elastic endpoint: "
+    read ELASTICSEARCH_ENDPOINT
+  fi
+
+  if [ -z "$ELASTICSEARCH_API_KEY" ]; then
+    printf "Enter your Elastic API key: "
+    read ELASTICSEARCH_API_KEY
+  fi
+  case "$SCENARIO" in
+    cloud-hosted)
+      kubectl create secret generic elastic-secret-otel \
+      --namespace opentelemetry-operator-system \
+      --from-literal=elastic_endpoint="$ELASTICSEARCH_ENDPOINT" \
+      --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY"
+
+      helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
+      --namespace opentelemetry-operator-system \
+      --values 'https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.3/deploy/helm/edot-collector/kube-stack/values.yaml' \
+      --version '0.3.3'
+      ;;
+    serverless)
+      
+      kubectl create secret generic elastic-secret-otel \
+      --namespace opentelemetry-operator-system \
+      --from-literal=elastic_otlp_endpoint="$ELASTICSEARCH_ENDPOINT" \
+      --from-literal=elastic_api_key="$ELASTICSEARCH_API_KEY"
+
+      helm install opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack \
+      --namespace opentelemetry-operator-system \
+      --values 'https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v9.1.3/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml' \
+      --version '0.3.3'
+      ;;
+  esac
+  helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yml
+fi
+
+echo "Done! '$SCENARIO' started on '$PLATFORM'."

--- a/kubernetes/elastic-helm/demo.yml
+++ b/kubernetes/elastic-helm/demo.yml
@@ -4,6 +4,33 @@ default:
     repository: ghcr.io/elastic/opentelemetry-demo
     tag: 2.0.4
   envOverrides:
+    - name: OTEL_SERVICE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.labels['app.kubernetes.io/component']
+    - name: OTEL_K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+         apiVersion: v1
+         fieldPath: metadata.namespace
+    - name: OTEL_K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+    - name: OTEL_K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: OTEL_K8S_POD_UID
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.uid
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: 'service.name=$(OTEL_SERVICE_NAME),service.instance.id=$(OTEL_K8S_POD_UID),service.namespace=opentelemetry-demo,k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(OTEL_K8S_NODE_NAME),k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.pod.uid=$(OTEL_K8S_POD_UID)'
     - name: OTEL_COLLECTOR_NAME
       value: "opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local"
 

--- a/src/otel-collector/otelcol-elastic-otlp-config.yaml
+++ b/src/otel-collector/otelcol-elastic-otlp-config.yaml
@@ -1,9 +1,9 @@
 exporters:
   debug:
   otlphttp/elastic:
-    endpoint: "YOUR_OTEL_EXPORTER_OTLP_ENDPOINT"
+    endpoint: ${env:ELASTICSEARCH_ENDPOINT}
     headers:
-      Authorization: "ApiKey YOUR_OTEL_EXPORTER_OTLP_API_KEY"
+      Authorization: "ApiKey ${env:ELASTICSEARCH_API_KEY}"
 
 receivers:
   otlp:


### PR DESCRIPTION
This PR introduces a script that automates the deployment of demo applications and EDOT, with configurations and wiring already in place. The only required input is Elastic credentials, streamlining the demo launch process.

The original manual configuration remains intact and can still be followed, especially if users prefer to provide a custom OTel Collector configuration.
