### PR TITLE
[k8s] Pin upstream demo helm version

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -78,7 +78,7 @@ Additionally, the OpenTelemetry Contrib collector has also been changed to the [
 - Follow the [EDOT Quick Start Guide](https://elastic.github.io/opentelemetry/quickstart/) for Kubernetes and your specific Elastic deployment to install the EDOT OpenTelemetry collector.
 - Deploy the Elastic OpenTelemetry Demo using the following command.
   ```
-  helm install my-otel-demo open-telemetry/opentelemetry-demo -f kubernetes/elastic-helm/demo.yml
+  helm install my-otel-demo open-telemetry/opentelemetry-demo --version 0.37.8 -f kubernetes/elastic-helm/demo.yml
   ```
 
 </details>

--- a/demo.sh
+++ b/demo.sh
@@ -11,10 +11,11 @@ HELM_REPO_URL='https://open-telemetry.github.io/opentelemetry-helm-charts'
 
 DEMO_RELEASE="my-otel-demo"
 DEMO_CHART="open-telemetry/opentelemetry-demo"
+DEMO_HELM_VERSION='0.37.8'
 
 KUBE_STACK_RELEASE="opentelemetry-kube-stack"
 KUBE_STACK_CHART="open-telemetry/opentelemetry-kube-stack"
-KUBE_STACK_VERSION='0.9.1'
+KUBE_STACK_VERSION='0.10.5'
 KUBE_STACK_VALUES_URL_CLOUD='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/values.yaml'
 KUBE_STACK_VALUES_URL_SERVERLESS='https://raw.githubusercontent.com/elastic/elastic-agent/refs/tags/v'$ELASTIC_STACK_VERSION'/deploy/helm/edot-collector/kube-stack/managed_otlp/values.yaml'
 SECRET_NAME='elastic-secret-otel'
@@ -162,7 +163,7 @@ install_kube_stack() {
 }
 
 install_demo_chart() {
-  helm upgrade --install "$DEMO_RELEASE" "$DEMO_CHART" -f kubernetes/elastic-helm/demo.yml
+  helm upgrade --install "$DEMO_RELEASE" "$DEMO_CHART" --version "$DEMO_HELM_VERSION" -f kubernetes/elastic-helm/demo.yml
 }
 
 start_k8s() {


### PR DESCRIPTION
# Changes

The current K8s installation process for always installs the latest version of the Opentelemetry Demo Helm Charts. This can cause inconsistencies when our fork is not fully up-to-date with upstream (see https://github.com/elastic/opentelemetry-demo/issues/168). 
This PR add a version pin to ensure to install a compatible version of the charts (at this time, 0.37.8)

It also updates the version of the our kube stack to `0.10.5`, to include this fix https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1877


