### PR TITLE
Add `JAEGER_PORT` env to frontend-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,6 +351,7 @@ services:
       - GRAFANA_HOST
       - JAEGER_UI_PORT
       - JAEGER_HOST
+      - JAEGER_PORT=${JAEGER_UI_PORT}      
       - OTEL_COLLECTOR_HOST
       - IMAGE_PROVIDER_HOST
       - IMAGE_PROVIDER_PORT


### PR DESCRIPTION
The frontend-proxy is not able to start and I am seeing this error:

```
[critical][main] [source/server/server.cc:412] error initializing config 'envoy.yaml': Proto constraint validation failed ... caused by field: "port_specifier", reason: is required
```

Adding `JAEGER_PORT` env fixes the problem

cc @girodav 