### PR TITLE
Add config for using minikube with local edot collector

### DIFF
--- a/kubernetes/elastic-helm/minikube.yaml
+++ b/kubernetes/elastic-helm/minikube.yaml
@@ -4,7 +4,7 @@
 # Usage:
 #   helm install otel-demo open-telemetry/opentelemetry-demo -n otel-demo --create-namespace \
 #     -f kubernetes/elastic-helm/demo.yml \
-#     -f kubernetes/local-edot.yaml
+#     -f kubernetes//elastic-helm/minikube.yaml
 
 default:
   envOverrides:


### PR DESCRIPTION
This PR adds a Helm values file (minikube.yaml) that configures the OpenTelemetry Demo to send telemetry to a local EDOT collector running on the host machine. This enables a simpler development workflow for Kibana developers who want to test o11y features with Kubernetes-generated telemetry.

### 1. Start Kibana + ES + edot collector (in Kibana repo)
```
yarn start
yarn es snapshot --license trial
node scripts/edot_collector.js
```

### 2. Start minikube
```
minikube start --memory=8192 --cpus=4
```

### 3. Install OTel demo
```
helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
helm upgrade --install otel-demo open-telemetry/opentelemetry-demo \
  --namespace otel-demo --create-namespace \
  -f kubernetes/elastic-helm/demo.yml \
  -f kubernetes/elastic-helm/minikube.yaml \
  --version 0.38.3
```

### 4. Port forwarding
```
kubectl port-forward -n otel-demo svc/frontend-proxy 8080:8080
```

cc @SrdjanLL