### PR TITLE
Configs for generating SemConv-only and ECS-only telemetry

### DIFF
--- a/src/otel-collector/otelcol-elastic-ecs-docker.yaml
+++ b/src/otel-collector/otelcol-elastic-ecs-docker.yaml
@@ -1,0 +1,230 @@
+exporters:
+  debug:
+  elasticsearch/otel:
+    endpoints:
+      - ${env:ELASTICSEARCH_ENDPOINT}
+    api_key: ${env:ELASTICSEARCH_API_KEY}
+    logs_dynamic_index:
+      enabled: true
+    metrics_dynamic_index:
+      enabled: true
+    traces_dynamic_index:
+      enabled: true
+    mapping:
+      mode: otel
+  elasticsearch/ecs:
+    endpoints:
+      - ${env:ELASTICSEARCH_ENDPOINT}
+    api_key: ${env:ELASTICSEARCH_API_KEY}
+    logs_dynamic_index:
+      enabled: true
+    metrics_dynamic_index:
+      enabled: true
+    mapping:
+      mode: ecs
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_GRPC}
+      http:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_HTTP}
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+  httpcheck/frontendproxy:
+    targets:
+      - endpoint: http://frontendproxy:${env:ENVOY_PORT}
+  hostmetrics:
+    collection_interval: 10s
+    root_path: /hostfs
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+          system.cpu.logical.count:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+        metrics:
+          process.threads:
+            enabled: true
+          process.open_file_descriptors:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.disk.operations:
+            enabled: true
+      network:
+      processes:
+      load:
+      disk:
+      filesystem:
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/k3s/containerd/*
+            - /var/lib/docker/*
+            - /var/lib/kubelet/*
+            - /snap/*
+          match_type: regexp
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+          match_type: strict
+
+processors:
+  batch/aggs:
+    send_batch_size: 16384 # 2x the default
+    timeout: 10s
+  batch:
+  batch/metrics:
+    # explicitly set send_batch_max_size to 0, as splitting metrics requests may cause version_conflict_engine_exception in TSDB
+    send_batch_max_size: 0
+    timeout: 1s
+  elasticinframetrics:
+    add_system_metrics: true
+    add_k8s_metrics: false
+    drop_original: true
+  resource/process:
+    attributes:
+      - key: process.executable.name
+        action: delete
+      - key: process.executable.path
+        action: delete
+  attributes/dataset:
+    actions:
+      - key: event.dataset
+        from_attribute: data_stream.dataset
+        action: upsert
+  resourcedetection/system:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.id:
+          enabled: false
+        host.arch:
+          enabled: true
+        host.ip:
+          enabled: true
+        host.mac:
+          enabled: true
+        host.cpu.vendor.id:
+          enabled: true
+        host.cpu.family:
+          enabled: true
+        host.cpu.model.id:
+          enabled: true
+        host.cpu.model.name:
+          enabled: true
+        host.cpu.stepping:
+          enabled: true
+        host.cpu.cache.l2.size:
+          enabled: true
+        os.description:
+          enabled: true
+        os.type:
+          enabled: true
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # could be removed when https://github.com/vercel/next.js/pull/64852 is fixed upstream
+          - replace_pattern(name, "\\?.*", "")
+          - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
+  # [Elastic Trace Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor)
+  elastictrace: {} # The processor enriches traces with elastic specific requirements.
+
+connectors:
+  spanmetrics:
+  elasticapm:
+
+service:
+  pipelines:
+    logs:
+      exporters:
+        - debug
+        - elasticsearch/otel
+      processors:
+        - batch
+      receivers:
+        - otlp
+    metrics/infra:
+      exporters:
+        - elasticsearch/ecs
+        - debug
+      processors:
+        - batch/metrics
+        - elasticinframetrics
+        - resourcedetection/system
+        - attributes/dataset
+        - resource/process
+      receivers:
+        - hostmetrics
+    metrics:
+      exporters:
+        - elasticsearch/otel
+        - elasticapm
+        - debug
+      processors:
+        - batch/metrics
+      receivers:
+        - httpcheck/frontendproxy
+        - otlp
+        - spanmetrics
+    traces:
+      exporters:
+        - elasticsearch/otel
+        - debug
+        - spanmetrics
+        - elasticapm
+      processors:
+        - transform
+        - batch
+        - elastictrace
+      receivers:
+        - otlp
+    metrics/aggregated-otel-metrics:
+      receivers:
+        - elasticapm
+      processors:
+      exporters:
+        - debug
+        - elasticsearch/otel

--- a/src/otel-collector/otelcol-elastic-semconv-docker.yaml
+++ b/src/otel-collector/otelcol-elastic-semconv-docker.yaml
@@ -1,0 +1,217 @@
+exporters:
+  debug:
+  elasticsearch/otel:
+    endpoints:
+      - ${env:ELASTICSEARCH_ENDPOINT}
+    api_key: ${env:ELASTICSEARCH_API_KEY}
+    logs_dynamic_index:
+      enabled: true
+    metrics_dynamic_index:
+      enabled: true
+    traces_dynamic_index:
+      enabled: true
+    mapping:
+      mode: otel
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_GRPC}
+      http:
+        endpoint: ${env:OTEL_COLLECTOR_HOST}:${env:OTEL_COLLECTOR_PORT_HTTP}
+        cors:
+          allowed_origins:
+            - "http://*"
+            - "https://*"
+  httpcheck/frontendproxy:
+    targets:
+      - endpoint: http://frontendproxy:${env:ENVOY_PORT}
+  hostmetrics:
+    collection_interval: 10s
+    root_path: /hostfs
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+          system.cpu.logical.count:
+            enabled: true
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      process:
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
+        metrics:
+          process.threads:
+            enabled: true
+          process.open_file_descriptors:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.disk.operations:
+            enabled: true
+      network:
+      processes:
+      load:
+      disk:
+      filesystem:
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/k3s/containerd/*
+            - /var/lib/docker/*
+            - /var/lib/kubelet/*
+            - /snap/*
+          match_type: regexp
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+          match_type: strict
+
+processors:
+  batch/aggs:
+    send_batch_size: 16384 # 2x the default
+    timeout: 10s
+  batch:
+  batch/metrics:
+    # explicitly set send_batch_max_size to 0, as splitting metrics requests may cause version_conflict_engine_exception in TSDB
+    send_batch_max_size: 0
+    timeout: 1s
+  elasticinframetrics:
+    add_system_metrics: true
+    add_k8s_metrics: false
+    drop_original: true
+  resource/process:
+    attributes:
+      - key: process.executable.name
+        action: delete
+      - key: process.executable.path
+        action: delete
+  attributes/dataset:
+    actions:
+      - key: event.dataset
+        from_attribute: data_stream.dataset
+        action: upsert
+  resourcedetection/system:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.id:
+          enabled: false
+        host.arch:
+          enabled: true
+        host.ip:
+          enabled: true
+        host.mac:
+          enabled: true
+        host.cpu.vendor.id:
+          enabled: true
+        host.cpu.family:
+          enabled: true
+        host.cpu.model.id:
+          enabled: true
+        host.cpu.model.name:
+          enabled: true
+        host.cpu.stepping:
+          enabled: true
+        host.cpu.cache.l2.size:
+          enabled: true
+        os.description:
+          enabled: true
+        os.type:
+          enabled: true
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # could be removed when https://github.com/vercel/next.js/pull/64852 is fixed upstream
+          - replace_pattern(name, "\\?.*", "")
+          - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
+  # [Elastic Trace Processor](https://github.com/elastic/opentelemetry-collector-components/tree/main/processor/elastictraceprocessor)
+  elastictrace: {} # The processor enriches traces with elastic specific requirements.
+
+connectors:
+  spanmetrics:
+  elasticapm:
+
+service:
+  pipelines:
+    logs:
+      exporters:
+        - debug
+        - elasticsearch/otel
+      processors:
+        - batch
+      receivers:
+        - otlp
+    metrics/infra:
+      exporters:
+        - elasticsearch/otel
+        - debug
+      processors:
+        - batch/metrics
+        - resourcedetection/system
+      receivers:
+        - hostmetrics
+    metrics:
+      exporters:
+        - elasticsearch/otel
+        - elasticapm
+        - debug
+      processors:
+        - batch/metrics
+      receivers:
+        - httpcheck/frontendproxy
+        - otlp
+        - spanmetrics
+    traces:
+      exporters:
+        - elasticsearch/otel
+        - debug
+        - spanmetrics
+        - elasticapm
+      processors:
+        - transform
+        - batch
+        - elastictrace
+      receivers:
+        - otlp
+    metrics/aggregated-otel-metrics:
+      receivers:
+        - elasticapm
+      processors:
+      exporters:
+        - debug
+        - elasticsearch/otel


### PR DESCRIPTION
The default config otel collector config  (`./src/otel-collector/otelcol-elastic-config.yaml`) produces both ECS and SemConv (OpenTelemetry semantic conventions) telemetry. It can be useful to only generate one of these formats in order to ensure that UIs support either of those. 

This PR adds configs for ECS-only and SemConv-only telemetry

Add to .env.override to generate ECS-only telemetry:
```yml
OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-ecs-docker.yaml 
```

Add to .env.override for SemConv-only telemetry:
```yml
OTEL_COLLECTOR_CONFIG=./src/otel-collector/otelcol-elastic-semconv-docker.yaml
```

**Determine schema of available o11y data**

The telemetry schema can be verified in Kibana Dev Tools by running this command (update the timestamps)

```
GET kbn://api/metrics/source/time_range_metadata?from=2025-12-19T23%3A02%3A51.045Z&to=2025-12-21T23%3A17%3A51.046Z&dataSource=host
```