### PR TITLE
Remove cache usage in release workflows to reduce the cache poisoning vector attack

### DIFF
--- a/.github/workflows/component-build-images.yml
+++ b/.github/workflows/component-build-images.yml
@@ -200,16 +200,12 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           image: tonistiigi/binfmt:master
-          # NOTE: disable the cache poisoning vector attack
-          cache-image: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config-inline: |
             [worker.oci]
             max-parallelism = 2
-          # NOTE: disable the cache poisoning vector attack
-          cache-binary: false
       - name: Matrix Build and push demo images
         if: steps.check_changes.outputs.skip == 'false'
         uses: docker/build-push-action@v6.18.0
@@ -227,6 +223,5 @@ jobs:
             ${{ inputs.dockerhub_repo }}:latest-${{matrix.file_tag.tag_suffix }}
             ${{ inputs.ghcr_repo }}:${{ inputs.version }}-${{ matrix.file_tag.tag_suffix }}
             ${{ inputs.ghcr_repo }}:latest-${{ matrix.file_tag.tag_suffix }}
-          # NOTE: disable the cache poisoning vector attack
-          # cache-from: type=gha
-          # cache-to: type=gha
+          cache-from: type=gha
+          cache-to: type=gha


### PR DESCRIPTION
# Changes

After a deep analysis, remove cache usage in release related workflows to reduce the [cache poisoning](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/) vector attack.

## Why

In the context of Docker builds, the `docker/build-push-action` uses the GitHub Actions cache backend (type=gha) to optimise build times by reusing previously built layers.
However, if a workflow running untrusted code has access to the cache, it can poison the cache with malicious content. For example, a compromised dependency could inject malicious code into a Golang binary or Docker image, which would then be included in subsequent builds using the same cache key.
We have similar risks in the `docker/setup-qemu-action` which is caching images by default and in the `docker/setup-buildx-action` which is caching binaries by default as well.

This attack is particularly dangerous because the malicious artefact can be signed and distributed as part of an SLSA Level 3 build, leaving no trace in the source code or build logs.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
