### PR TITLE
POC: Remove opensearch, grafana, jaeger, prometheus

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,17 @@
+services:
+  opensearch: !reset
+  grafana: !reset
+  jaeger: !reset
+  prometheus: !reset
+  otel-collector:
+    depends_on: !override
+      flagd:
+        condition: service_started
+  frontend-proxy:
+    depends_on: !override
+      flagd:
+        condition: service_started
+      frontend:
+        condition: service_started
+      image-provider:
+        condition: service_started


### PR DESCRIPTION
# Changes

This commits the docker-compose.override.yml file to the elastic fork of the otel demo. This is done to remove the mentioned services. We remove the same services when running the demo in k8s.

Here we are using the `docker-compose.override.yml` file. This is `.gitignored` upstream. But we can add it with `git add -f`.

The result here shows that the following services are not ran when running the demo with docker:

```bash
opentelemetry-demo poc-docker-remove-services ❯ ./demo.sh
----------------------------------------------------
🚀 OpenTelemetry Demo with Elastic Observability
----------------------------------------------------

❓ Which Elasticsearch deployment type do you want to send the data into? [serverless/cloud-hosted]? serverless

❓ In which environment the demo should be deployed? [docker/k8s]? docker

⌛️ Starting OTel Demo + EDOT on 'docker' → Elastic (serverless)...

🔑 Enter your Elastic OTLP endpoint: https://otel-demo-test-b0d77d.ingest.europe-west1.gcp.elastic.cloud:443
🔑 Enter your Elastic API key:

docker compose --env-file .env --env-file .env.override up --force-recreate --remove-orphans --detach
[+] up 25/25
 ✔ Network opentelemetry-demo Created                                                                                                                                          0.0s
 ✔ Container kafka            Healthy                                                                                                                                         41.3s
 ✔ Container valkey-cart      Created                                                                                                                                          0.1s
 ✔ Container postgresql       Created                                                                                                                                          0.1s
 ✔ Container flagd            Created                                                                                                                                          0.1s
 ✔ Container llm              Created                                                                                                                                          0.1s
 ✔ Container otel-collector   Created                                                                                                                                          0.1s
 ✔ Container payment          Created                                                                                                                                          0.1s
 ✔ Container cart             Created                                                                                                                                          0.1s
 ✔ Container fraud-detection  Created                                                                                                                                          0.1s
 ✔ Container product-catalog  Created                                                                                                                                          0.1s
 ✔ Container flagd-ui         Created                                                                                                                                          0.1s
 ✔ Container email            Created                                                                                                                                          0.1s
 ✔ Container currency         Created                                                                                                                                          0.1s
 ✔ Container shipping         Created                                                                                                                                          0.1s
 ✔ Container ad               Created                                                                                                                                          0.1s
 ✔ Container image-provider   Created                                                                                                                                          0.1s
 ✔ Container accounting       Created                                                                                                                                          0.1s
 ✔ Container quote            Created                                                                                                                                          0.1s
 ✔ Container product-reviews  Created                                                                                                                                          0.1s
 ✔ Container recommendation   Created                                                                                                                                          0.1s
 ✔ Container checkout         Created                                                                                                                                          0.0s
 ✔ Container frontend         Created                                                                                                                                          0.0s
 ✔ Container load-generator   Created                                                                                                                                          0.1s
 ✔ Container frontend-proxy   Created                                                                                                                                          0.0s

OpenTelemetry Demo is running.
Go to http://localhost:8080 for the demo UI.
Go to http://localhost:8080/jaeger/ui for the Jaeger UI.
Go to http://localhost:8080/grafana/ for the Grafana UI.
Go to http://localhost:8080/loadgen/ for the Load Generator UI.
Go to http://localhost:8080/feature/ to change feature flags.

🎉 OTel Demo and EDOT are running on 'docker'; data is flowing to Elastic (serverless).
```