### PR TITLE
Update ad, fraud-detection, and kafka memory limits

### DIFF
--- a/.env.override
+++ b/.env.override
@@ -8,9 +8,9 @@ IMAGE_NAME=ghcr.io/elastic/opentelemetry-demo
 # *********************
 # Elastic Demo Services
 # *********************
-AD_SERVICE_DOCKERFILE=./src/ad/Dockerfile.elastic
-FRAUD_SERVICE_DOCKERFILE=./src/fraud-detection/Dockerfile.elastic
-KAFKA_SERVICE_DOCKERFILE=./src/kafka/Dockerfile.elastic
+AD_DOCKERFILE=./src/ad/Dockerfile.elastic
+FRAUD_DOCKERFILE=./src/fraud-detection/Dockerfile.elastic
+KAFKA_DOCKERFILE=./src/kafka/Dockerfile.elastic
 
 # *********************
 # Elastic Collector

--- a/kubernetes/elastic-helm/demo.yml
+++ b/kubernetes/elastic-helm/demo.yml
@@ -35,6 +35,15 @@ default:
       value: "opentelemetry-kube-stack-daemon-collector.opentelemetry-operator-system.svc.cluster.local"
 
 components:
+  fraud-detection:
+    resources:
+      limits:
+        memory: 512Mi
+  kafka:
+    resources:
+      limits:
+        memory: 800Mi
+
   load-generator:
     envOverrides:
       - name: LOCUST_BROWSER_TRAFFIC_ENABLED

--- a/src/ad/Dockerfile.elastic
+++ b/src/ad/Dockerfile.elastic
@@ -43,7 +43,7 @@ COPY --from=builder /usr/src/app/ ./
 
 COPY --from=intermediate /opentelemetry-javaagent.jar /usr/src/app/opentelemetry-javaagent.jar
 
-ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
+ENV JAVA_TOOL_OPTIONS="-javaagent:/usr/src/app/opentelemetry-javaagent.jar -Xmx200m"
 ENV OTEL_INFERRED_SPANS_ENABLED=true
 ENV ELASTIC_OTEL_SPAN_STACK_TRACE_MIN_DURATION=2
 

--- a/src/fraud-detection/Dockerfile.elastic
+++ b/src/fraud-detection/Dockerfile.elastic
@@ -32,7 +32,7 @@ WORKDIR /usr/src/app/
 COPY --from=builder /usr/src/app/build/libs/fraud-detection-1.0-all.jar ./
 COPY --from=intermediate /opentelemetry-javaagent.jar /usr/src/app/opentelemetry-javaagent.jar
 
-ENV JAVA_TOOL_OPTIONS=-javaagent:/usr/src/app/opentelemetry-javaagent.jar
+ENV JAVA_TOOL_OPTIONS="-javaagent:/usr/src/app/opentelemetry-javaagent.jar -Xmx200m"
 ENV ELASTIC_OTEL_INFERRED_SPANS_ENABLED=true
 ENV ELASTIC_OTEL_SPAN_STACK_TRACE_MIN_DURATION=2
 


### PR DESCRIPTION
Fixes #208 

# Changes

This work updates the ad, fraud-detection, and kafka services in the elastic otel demo to set there memory limits.

## Java Heap

The java heap limit to 200m. The Java heap has been set to 200m, if we don't the heap is dynamically set to 25% of available memory. So if the heap is 1gig and the service has a memory setting of 300Mi the service will OOMKILL straight away.

> [!IMPORTANT]
> This will only happen if you give k8s unlimited memory, for example, this is the default in kind.

Running kind locally with an unlimited memory setting we can see that the JVM running on the ad service has an unlimited setting:

```bash
opentelemetry-demo elastic-main  ✗ kubectl exec -it $(kubectl get pod -l app.kubernetes.io/component=ad -o jsonpath='{.items[0].metadata.name}') -- java -XshowSettings:system -version 2>&1 | grep -i memory
    List of Memory Nodes: N/A
    List of Available Memory Nodes, 1 total:
    Memory Limit: Unlimited
    Memory Soft Limit: 0.00K
    Memory & Swap Limit: Unlimited
```

This means that the heap is massive, which causes the ad service to continuously restart due to its cgroup limit of 300Mi. The Java heap size alone for the ad service is way past 300Mi.

## Memory settings

The memory limit for fraud-detection has been set to 512Mi and kafka to 800Mi. This has been done because if you remove the memory limit for both they consume more than allocated. If left unchanged this causes OOMKILL when running in k8s.

## Env vars for elastic dockerfiles

The `.env.override` file is incorrectly referencing env vars for:

- AD_SERVICE_DOCKERFILE=./src/ad/Dockerfile.elastic
- FRAUD_SERVICE_DOCKERFILE=./src/fraud-detection/Dockerfile.elastic
- KAFKA_SERVICE_DOCKERFILE=./src/kafka/Dockerfile.elastic

Upstream the services names have changed to remove `service` from the name, see upstream PR: https://github.com/open-telemetry/opentelemetry-demo/pull/1832.

In the fork we need to rename these `.env` vars for the above services otherwise the elastic Dockerfiles will not be used when generating images.

- [AD_DOCKERFILE](https://github.com/elastic/opentelemetry-demo/blob/dd5fe004ae0ade3f1d95d32a75d446c6a3f4dc68/docker-compose.yml?plain=1#L55)
- [FRAUD_DOCKERFILE](https://github.com/elastic/opentelemetry-demo/blob/dd5fe004ae0ade3f1d95d32a75d446c6a3f4dc68/docker-compose.yml?plain=1#L240)
- [KAFKA_DOCKERFILE](https://github.com/elastic/opentelemetry-demo/blob/dd5fe004ae0ade3f1d95d32a75d446c6a3f4dc68/docker-compose.yml?plain=1#L725)

## Memory Allocation

If we remove the memory limit for ad, fraud-dection and kafka:

```bash
opentelemetry-demo elastic-main  ❯ kubectl top pods
NAME                               CPU(cores)   MEMORY(bytes)
ad-6f78bf97bf-cmrsw                12m          408Mi
...
fraud-detection-76d8576f77-rnxmh   18m          417Mi
...
kafka-cf995f697-sgjt5              31m          608Mi
...
```

And the helm chart for the otel demo limits these to:

- [ad](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml#L214): 300Mi
- [fraud-detection](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml#L351): 300Mi
- [kafka](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-demo/values.yaml#L808): 600Mi

The reason this has to be done for just the fork is that the fork adds specific elastic instrumentation to the mentioned services above. This add memory pressure to these services that isn't seen in the upstream otel-demo.

### Default memory limits

```bash
NAMESPACE                       NAME                                                              READY   STATUS      RESTARTS       AGE
default                         accounting-6b5dfb9c7-9bdcv                                        1/1     Running     0              85s
default                         ad-7dd9f6d95f-dlbmw                                               0/1     OOMKilled   3 (40s ago)    85s
default                         cart-9b8444979-qs8zl                                              1/1     Running     0              85s
default                         checkout-6456fc9f4c-xvb47                                         1/1     Running     0              83s
default                         currency-795fb77fc7-8rtwq                                         1/1     Running     0              85s
default                         email-5877c9bd49-xxmtf                                            1/1     Running     0              84s
default                         flagd-5495d64d64-hjpp9                                            2/2     Running     0              85s
default                         fraud-detection-6c5d746847-cvpj5                                  0/1     OOMKilled   1 (22s ago)    85s
default                         frontend-585dd7c89c-kv47m                                         1/1     Running     0              84s
default                         frontend-proxy-78569fb9cf-fsm2p                                   1/1     Running     0              84s
default                         image-provider-c55cd4ff7-rx75g                                    1/1     Running     0              85s
default                         kafka-59889c4cf9-pvhfs                                            1/1     Running     1 (58s ago)    84s
```

### Removed memory limits for ad, fraud-detection and kafka

```bash
NAMESPACE                       NAME                                                              READY   STATUS    RESTARTS       AGE
default                         accounting-6b5dfb9c7-2ldkb                                        1/1     Running   4 (33m ago)    147m
default                         ad-6f78bf97bf-cmrsw                                               1/1     Running   0              40m
default                         cart-9b8444979-mmwb4                                              1/1     Running   0              147m
default                         checkout-6456fc9f4c-n7pv5                                         1/1     Running   0              147m
default                         currency-795fb77fc7-km794                                         1/1     Running   0              147m
default                         email-5877c9bd49-xf2lv                                            1/1     Running   0              147m
default                         flagd-5495d64d64-kgkmd                                            2/2     Running   0              147m
default                         fraud-detection-76d8576f77-rnxmh                                  1/1     Running   0              40m
default                         frontend-585dd7c89c-ptnrc                                         1/1     Running   0              147m
default                         frontend-proxy-78569fb9cf-6xnks                                   1/1     Running   0              147m
default                         image-provider-c55cd4ff7-xwmbf                                    1/1     Running   0              147m
default                         kafka-cf995f697-sgjt5                                             1/1     Running   0              27m
default                         load-generator-f79d76c69-c2k86                                    1/1     Running   0              147m
default                         payment-bf5c94c99-85pwd                                           1/1     Running   0              147m
default                         postgresql-59b6cb8b95-fpnjq                                       1/1     Running   0              147m
default                         product-catalog-7b877b7d4c-h4vpx                                  1/1     Running   0              147m
default                         quote-58f984887b-xbqzx                                            1/1     Running   0              147m
default                         recommendation-69fb5f4655-p2fsm                                   1/1     Running   0              147m
default                         shipping-5f7f55dbc7-csp7c                                         1/1     Running   0              147m
default                         valkey-cart-596b4f6c6c-tkmvf                                      1/1     Running   0              147m
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
