### PR TITLE
[docs] Update no edot docs with upstream version and links to upstream documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -68,6 +68,8 @@ For users who do not want to use the Elastic Distribution of OpenTelemetry (EDOT
 This mode uses the standard OpenTelemetry Collector contrib image with OTLP HTTP export configured for Elastic, 
 rather than the EDOT collector, also we do not use EDOT SDKs either, here we use the OTel SDKs to instrument services. All telemetry (traces, metrics, logs) is routed to Elastic via OTLP.
 
+> **Note**: This mode has been tested with [upstream release 2.2.0](https://github.com/open-telemetry/opentelemetry-demo/releases/tag/2.2.0). Some Elastic dashboards may not be fully populated compared to EDOT mode. For general demo documentation, see the [upstream docs](https://opentelemetry.io/docs/demo/).
+
 ### Connect to a local Elasticsearch cluster
 The following steps shows how to start the Otel demo in a Docker container and send the generated otel data to an Elasticsearch instance running locally on the host.
 
@@ -136,6 +138,8 @@ For users who do not want to use the Elastic Distribution of OpenTelemetry (EDOT
 
 This mode uses the standard OpenTelemetry Collector contrib image with OTLP HTTP export configured for Elastic, 
 rather than the EDOT collector, also we do not use EDOT SDKs either, here we use the OTel SDKs to instrument services. All telemetry (traces, metrics, logs) is routed to Elastic via OTLP.
+
+> **Note**: This mode has been tested with [upstream release 2.2.0](https://github.com/open-telemetry/opentelemetry-demo/releases/tag/2.2.0). Some Elastic dashboards may not be fully populated compared to EDOT mode. For general demo documentation, see the [upstream docs](https://opentelemetry.io/docs/demo/).
 
 ### Manual Installation
 


### PR DESCRIPTION
# Changes

This PR updates docs for running the demo in "upstream" mode.

Here we are documenting the upstream version that this has been tested against and added links to upstream docs. Also known limitations have been added.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
