### PR TITLE
[bug-fix] Fix bashunit error ci tests

### DIFF
--- a/.github/workflows/run-integration-tests-elastic.yml
+++ b/.github/workflows/run-integration-tests-elastic.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install bashunit
       run: |
-        curl -s https://bashunit.typeddevs.com/install.sh | bash -s bin
+        curl -sSL https://bashunit.com/install.sh | bash -s bin
 
     - name: Run the tests
       run: |


### PR DESCRIPTION
# Changes

Currently the CI integration tests fail for the elastic otel demo.

This happens because bashunit have move the location of their install script, see [here](https://bashunit.com/installation).

Existing URL:  `curl -s https://bashunit.typeddevs.com/install.sh | bash -s bin`
New URL:  `curl -sSL https://bashunit.com/install.sh | bash -s bin`

The existing url we use in the github workflow returns a 301, see below

```bash
opentelemetry-demo fix-bashunit-error-ci-tests ❯ curl -sI https://bashunit.typeddevs.com/install.sh
HTTP/2 301
date: Wed, 17 Jun 2026 11:30:43 GMT
content-type: text/html; charset=UTF-8
location: https://bashunit.com/install.sh
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=c1dWeentBmDZP6As5U30oUz1d8ehELWSkWqQPsXZxPnt131fb4YvFpFvzPdlE4%2B5VsFy8yMPu8uAFT1wahpCtDrTP1j%2BiHF8kUgxZay4EotsGvertq2ajPULSmCtggMtnMGv%2Fr3wivlSHGzLbuLcoA48FBYq"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: a0d1b94b8a9bbdd2-DUB
```

The new URL fixes the issue: (we now also use -S to surface errors and -L to redirect if needed)

```bash
opentelemetry-demo fix-bashunit-error-ci-tests ❯ curl -sSL https://bashunit.com/install.sh | head -20
#!/usr/bin/env bash
# shellcheck disable=SC2155
# shellcheck disable=SC2164

# Helper function for regex matching (Bash 3.0+ compatible)
function regex_match() {
  [[ $1 =~ $2 ]]
}

function is_git_installed() {
  command -v git >/dev/null 2>&1
}

function compute_sha256() {
  if command -v shasum >/dev/null 2>&1; then
    shasum -a 256 "$1" | awk '{print $1}'
  elif command -v sha256sum >/dev/null 2>&1; then
    sha256sum "$1" | awk '{print $1}'
  else
    echo ""
```

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
