### PR TITLE
Automate upstream sync with Copilot

### DIFF
--- a/.github/UPSTREAM_SYNC.md
+++ b/.github/UPSTREAM_SYNC.md
@@ -1,0 +1,27 @@
+# Automated upstream synchronization
+
+The `Merge Upstream PR` workflow checks `open-telemetry/opentelemetry-demo`
+twice a week and on manual dispatch. When new commits exist and no sync is
+already open, it starts the `elastic-upstream-sync` Copilot agent. Copilot
+performs the merge, resolves conflicts according to the agent profile, and
+opens a pull request against this repository's `main` branch.
+
+## Required setup
+
+1. Enable GitHub Copilot cloud agent for the repository and the user represented
+   by the token. Starting tasks through the API requires Copilot Business or
+   Copilot Enterprise.
+2. Create a fine-grained personal access token with read/write access to the
+   repository's Agent tasks permission.
+3. Store that token as the repository Actions secret
+   `COPILOT_AGENT_TOKEN`.
+4. Review and approve the exact task prompt in `merge-upstream.yaml` before
+   enabling the schedule. Repository policy does not allow an AI agent to author
+   issue or pull request discussion text.
+
+The token must be a user-to-server token. The built-in `GITHUB_TOKEN` and GitHub
+App installation tokens cannot start Copilot cloud agent tasks.
+
+The workflow does not start another sync while any Copilot task is active in the
+repository or a pull request with the title
+`chore: merge upstream open-telemetry/opentelemetry-demo` is open.

--- a/.github/agents/elastic-upstream-sync.agent.md
+++ b/.github/agents/elastic-upstream-sync.agent.md
@@ -1,0 +1,64 @@
+---
+name: elastic-upstream-sync
+description: >-
+  Merges open-telemetry/opentelemetry-demo main into the Elastic fork while
+  preserving its Elastic distributions and deployment modes
+target: github-copilot
+tools: ["read", "search", "edit", "execute"]
+disable-model-invocation: true
+---
+
+Merge `open-telemetry/opentelemetry-demo` branch `main` into this repository's
+`main` branch. Use a merge commit; do not rebase or squash the upstream history.
+
+Before changing files:
+
+- Read `AGENTS.md`, `CONTRIBUTING.md`, and `.github/README.md` completely.
+- Add or verify an `upstream` remote pointing exactly to
+  `https://github.com/open-telemetry/opentelemetry-demo.git`, fetch
+  `upstream/main`, and inspect both sides of every conflict.
+- Treat upstream as the source of truth for the demo's architecture, APIs,
+  generated files, dependency upgrades, and newly added features. Adapt the
+  Elastic integration to those changes instead of restoring obsolete upstream
+  code.
+
+Preserve these Elastic-specific capabilities:
+
+- Elastic distributions of the OpenTelemetry agents for the Ad, Fraud
+  Detection, Kafka, Cart, Payment, and Recommendation services. Keep the
+  corresponding manifests, lockfiles, build files, startup commands, and
+  `Dockerfile.elastic` files consistent.
+- The Elastic OpenTelemetry Collector distribution and the Elastic collector
+  configuration overlays.
+- Elastic Docker Compose modes, including Elastic Cloud, self-hosted
+  `start-local`, and upstream/no-EDOT mode.
+- Elastic Kubernetes Helm values and deployment overlays.
+- `demo.sh`, Elastic CI/release/integration-test workflows, and Elastic
+  documentation and images.
+- Existing upstream services and optional compose layers, including agent,
+  chatbot, MCP, observability, extras, and profiling layers.
+
+Resolve conflicts semantically. Do not choose all of `ours` or all of `theirs`.
+Start with the current upstream structure and reapply the Elastic behavior in
+the appropriate new locations. Regenerate dependency lockfiles and generated
+artifacts with the repository's documented tools when their source manifests
+change.
+
+Never add credentials or local values from `.env.override`. Keep its committed
+placeholder form, and do not expose secret values in output, commits, issue
+text, or pull request text.
+
+Before finishing:
+
+- Confirm there are no unmerged paths or conflict markers.
+- Review the complete diff against `main` and verify that unrelated
+  Elastic-only files were not deleted.
+- Run the checks required by `CONTRIBUTING.md`, plus targeted builds or tests
+  for every conflicted service. At minimum validate the complete Docker Compose
+  configuration used by the Elastic demo.
+- Commit the merge with an `Assisted-by: GitHub Copilot` trailer.
+- Create a pull request targeting this repository's `main` branch. Use the exact
+  title `chore: merge upstream open-telemetry/opentelemetry-demo` and leave the
+  pull request body empty. Do not post issue or pull request comments;
+  repository policy requires that discussion text be written or approved
+  verbatim by a human.

--- a/.github/workflows/merge-upstream.yaml
+++ b/.github/workflows/merge-upstream.yaml
@@ -1,105 +1,125 @@
 name: Merge Upstream PR
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 9 * * 1,4'
 
-jobs:
-  create_upstream_pr:
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get token
-        id: get_token
-        uses: elastic/oblt-actions/github/create-token@v1
-        with:
-          token-policy: token-policy-e96fbab0a32e
+concurrency:
+  group: upstream-sync
+  cancel-in-progress: false
 
-      - name: Checkout
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  create-upstream-sync-task:
+    runs-on: ubuntu-latest
+    env:
+      TASK_TITLE: 'chore: merge upstream open-telemetry/opentelemetry-demo'
+    steps:
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ steps.get_token.outputs.token }}
-
-      - name: Configure git user
-        uses: elastic/oblt-actions/git/setup@v1
-        with:
-          github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Fetch upstream
         run: |
           git remote add upstream https://github.com/open-telemetry/opentelemetry-demo.git
-          git fetch upstream main
+          git fetch --no-tags upstream main
 
       - name: Check for upstream changes
-        id: check
+        id: upstream
         run: |
-          COMMITS_BEHIND=$(git rev-list --count HEAD..upstream/main)
-          echo "commits_behind=${COMMITS_BEHIND}" >> $GITHUB_OUTPUT
+          commits_behind=$(git rev-list --count HEAD..upstream/main)
+          echo "commits_behind=${commits_behind}" >> "$GITHUB_OUTPUT"
+          echo "upstream_sha=$(git rev-parse upstream/main)" >> "$GITHUB_OUTPUT"
 
-      - name: Create branch and merge upstream
-        if: steps.check.outputs.commits_behind != '0'
-        id: branch
+      - name: Check Copilot agent token
+        if: steps.upstream.outputs.commits_behind != '0'
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_AGENT_TOKEN }}
         run: |
-          BRANCH_NAME="auto-merge/upstream-$(date +%Y%m%d-%H%M%S)"
-          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
-      
-          # Create branch from main (which has all your Elastic changes)
-          git checkout -b "${BRANCH_NAME}" main
-          
-          # Attempt to merge upstream/main into it
-          git merge upstream/main --no-edit || echo "Merge conflicts detected"
-          
-          # Push the branch (even if there are conflicts)
-          git push origin "${BRANCH_NAME}"
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo 'COPILOT_AGENT_TOKEN is not configured.' >&2
+            exit 1
+          fi
 
-      - name: Create Pull Request
-        if: steps.check.outputs.commits_behind != '0'
-        id: cpr
-        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
-        with:
-          token: ${{ steps.get_token.outputs.token }}
-          branch: "${{ steps.branch.outputs.branch_name }}"
-          base: main
-          title: "chore: Merge with upstream opentelemetry-demo"
-          body: |
-            ## Automated upstream merge
-          
-            This PR merges with the upstream opentelemetry-demo repository.
-            
-            ### Changes from upstream
-            - ${{ steps.check.outputs.commits_behind }} new commits
-            
-            ### If there are conflicts
-            Check out this branch and resolve them:
-            \`\`\`bash
-            git fetch origin ${{ steps.branch.outputs.branch_name }}
-            git checkout ${{ steps.branch.outputs.branch_name }}
-            # resolve conflicts in your editor
-            git add .
-            git commit
-            git push
-            \`\`\`
-            
-            **Note:** If \`src/payment/package.json\` conflicts, take upstream version and add:
-            \`\`\`json
-            \"@elastic/opentelemetry-node\": \"1.5.0\"
-            \`\`\`
-            And update the start script to:
-            \`\`\`json
-            \"start\": \"OTEL_EXPORTER_OTLP_PROTOCOL=grpc node --require @elastic/opentelemetry-node index.js\"
-            \`\`\`
-            
-            ---
-            *This PR was automatically created.*
-          delete-branch: true
+      - name: Check for an open sync pull request
+        if: steps.upstream.outputs.commits_behind != '0'
+        id: existing_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          open_pr_count=$(gh api --method GET /search/issues \
+            -f q="repo:${GITHUB_REPOSITORY} is:pr is:open in:title \"${TASK_TITLE}\"" \
+            --jq '.total_count')
+          echo "open_pr_count=${open_pr_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for an active Copilot task
+        if: steps.upstream.outputs.commits_behind != '0'
+        id: existing_task
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_AGENT_TOKEN }}
+        run: |
+          active_task_count=$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/agents/repos/${GITHUB_REPOSITORY}/tasks" \
+            -f state='queued,in_progress,idle,waiting_for_user' \
+            --jq '.tasks | length')
+          echo "active_task_count=${active_task_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Start Copilot upstream sync
+        if: >-
+          steps.upstream.outputs.commits_behind != '0' &&
+          steps.existing_pr.outputs.open_pr_count == '0' &&
+          steps.existing_task.outputs.active_task_count == '0'
+        env:
+          COMMITS_BEHIND: ${{ steps.upstream.outputs.commits_behind }}
+          GH_TOKEN: ${{ secrets.COPILOT_AGENT_TOKEN }}
+          UPSTREAM_SHA: ${{ steps.upstream.outputs.upstream_sha }}
+        run: |
+          prompt="Merge ${COMMITS_BEHIND} new commit(s) from open-telemetry/opentelemetry-demo main at ${UPSTREAM_SHA} while preserving the Elastic-specific changes."
+
+          jq -n \
+            --arg prompt "$prompt" \
+            '{
+              prompt: $prompt,
+              base_ref: "main",
+              custom_agent: "elastic-upstream-sync",
+              create_pull_request: true
+            }' > "$RUNNER_TEMP/copilot-assignment.json"
+
+          gh api \
+            --method POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/agents/repos/${GITHUB_REPOSITORY}/tasks" \
+            --input "$RUNNER_TEMP/copilot-assignment.json"
+
+      - name: Summarize result
+        if: always()
+        env:
+          COMMITS_BEHIND: ${{ steps.upstream.outputs.commits_behind }}
+          JOB_STATUS: ${{ job.status }}
+          OPEN_PR_COUNT: ${{ steps.existing_pr.outputs.open_pr_count }}
+          ACTIVE_TASK_COUNT: ${{ steps.existing_task.outputs.active_task_count }}
+        run: |
+          if [[ "$JOB_STATUS" == 'failure' ]]; then
+            echo 'The upstream-sync task could not be created. Review the failed step above.' >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$COMMITS_BEHIND" == '0' ]]; then
+            echo 'The Elastic fork is up to date with upstream/main.' >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "$OPEN_PR_COUNT" != '0' || "$ACTIVE_TASK_COUNT" != '0' ]]; then
+            echo 'An agent task or upstream-sync pull request is already open.' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Assigned ${COMMITS_BEHIND} upstream commit(s) to Copilot." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   notify-failure:
-    needs: [create_upstream_pr]
+    needs: [create-upstream-sync-task]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -107,8 +127,8 @@ jobs:
         uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: "C0AA2B1949M"  #otel-demo-ci
+          channel-id: 'C0AA2B1949M'
           message: |
             :warning: Upstream merge workflow failed for `${{ github.repository }}@${{ github.ref_name }}`.
-            
+
             Please check <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the workflow run>.


### PR DESCRIPTION
# Changes

This replaces the existing upstream-merge workflow with an automated GitHub
Copilot task that can resolve merge conflicts while preserving the Elastic
customizations.

The workflow:

- Checks `open-telemetry/opentelemetry-demo` twice weekly and on manual dispatch.
- Compares the fork's `main` branch with `upstream/main`.
- Does nothing when there are no new upstream commits.
- Avoids duplicate work when a Copilot task or upstream-sync PR is already open.
- Starts the `elastic-upstream-sync` Copilot agent from `main`.
- Requests that Copilot create a PR containing a merge commit.
- Restricts the workflow's built-in token to read-only permissions.
- Keeps the user-scoped Copilot token limited to the steps that require it.

The custom Copilot agent instructs Copilot to resolve conflicts semantically:
use the current upstream architecture as the foundation, then reapply the
Elastic-specific behavior instead of selecting all of `ours` or `theirs`.

The preservation guidelines cover:

- Elastic OpenTelemetry distributions for the Ad, Fraud Detection, Kafka, Cart,
  Payment, and Recommendation services.
- Elastic collector images and configuration overlays.
- Elastic Cloud, self-hosted, and upstream/no-EDOT Docker Compose modes.
- Elastic Kubernetes Helm values and deployment overlays.
- `demo.sh`, Elastic CI, release and integration-test workflows, documentation,
  and images.
- New upstream services and optional Compose layers.
- Dependency lockfiles and generated artifacts.
- Protection against committing or exposing `.env.override` credentials.

The agent must run the repository checks and targeted tests, inspect the final
diff, ensure no conflicts remain, and add an `Assisted-by: GitHub Copilot`
commit trailer.

## Required setup

Before enabling the workflow:

1. Enable GitHub Copilot cloud agent for the repository.
2. Create a fine-grained personal access token with read/write access to the
   repository's **Agent tasks** permission.
3. Store the token as the Actions secret `COPILOT_AGENT_TOKEN`.

The Agent Tasks API currently requires Copilot Business or Enterprise and is in
public preview.

## Validation

- YAML syntax parsed successfully.
- Copilot task JSON generation and shell syntax validated locally.
- Markdown formatting and line lengths checked.
- `git diff --check` passed.
- End-to-end execution was not performed because it requires the repository
  secret and execution from the default branch.

## Merge Requirements

- [x] Documentation added in `.github/UPSTREAM_SYNC.md`.
- [x] `CHANGELOG.md` update is not applicable to this internal automation.
- [x] Helm chart updates are not applicable.