### PR TITLE
Run hostmetrics process scraper v1 metrics

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # Constants
-ELASTIC_STACK_VERSION="9.3.0"
+ELASTIC_STACK_VERSION="9.4.4"
 ENV_OVERRIDE_FILE=".env.override"
 NAMESPACE="opentelemetry-operator-system"
 HELM_REPO_NAME="open-telemetry"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -868,7 +868,11 @@ services:
         limits:
           memory: 1.5G
     restart: unless-stopped
-    command: ["--config", "/etc/otelcol-config.yml", "--config", "/etc/otelcol-config-extras.yml" ]
+    command: [
+      "--config", "/etc/otelcol-config.yml",
+      "--config", "/etc/otelcol-config-extras.yml",
+      "--feature-gates=+scraper.process.EmitV1SystemConventions"
+    ]
     user: 0:0
     volumes:
       - ${HOST_FILESYSTEM}:/hostfs:ro

--- a/src/otel-collector/otelcol-elastic-config.yaml
+++ b/src/otel-collector/otelcol-elastic-config.yaml
@@ -46,6 +46,14 @@ receivers:
             enabled: true
           process.disk.operations:
             enabled: true
+          process.context_switches:
+           enabled: true
+          process.cpu.utilization:
+           enabled: true
+          process.paging.faults:
+           enabled: true
+          process.uptime:
+           enabled: true
       network: {}
       processes: {}
       load: {}


### PR DESCRIPTION
# Changes

This work updates the edot otel-collector to run the hostmetrics process scraper v1 metrics using the feature gate
scraper.process.EmitV1SystemConventions. Also the various process metrics were enabled that are disabled by default. This is to perform e2e testing in Kibana.

This is only for docker.

## Running

To run:

`./demo.sh docker`

Provide the elasticsearch URL and API key.
